### PR TITLE
Allow legitimate dotted worker repo names

### DIFF
--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -51,19 +51,8 @@ type ForkHeadState = {
 }
 
 type DiscoveryProgressHandler = (message: string) => void
-
-
-const suspiciousRepoNamePattern = /\.(env|ya?ml|json|xml|php|css|js|ts|txt|log|ini|cfg|conf|toml)$/i
 const suspiciousOwnerNames = new Set([".well-known"])
-const suspiciousRepoNames = new Set([
-  "nodeinfo",
-  "admin-ajax.php",
-  "openid-configuration",
-  "assetlinks.json",
-  "ai-plugin.json",
-  "trust.txt",
-  "phpinfo.php",
-])
+const suspiciousRoutePairs = new Set(["admin/.env", "wp-admin/admin-ajax.php"])
 const REPO_HEAD_TIMEOUT_MS = 8000
 const supportedGitHubRepoHosts = new Set(["github.com", "www.github.com"])
 
@@ -151,9 +140,10 @@ export function parseGitHubRepoInput(input: string): GitHubRepoRef {
 export function describeSuspiciousRepoInput(repo: GitHubRepoRef): string | null {
   const owner = repo.owner.toLowerCase()
   const name = repo.name.toLowerCase()
+  const fullName = `${owner}/${name}`
 
-  if (repo.owner.startsWith(".") || repo.name.startsWith(".")) {
-    return "Owner or repository name starts with a hidden-path prefix."
+  if (repo.owner.startsWith(".")) {
+    return "Owner segment starts with a hidden-path prefix."
   }
 
   if (repo.owner.includes("%") || repo.name.includes("%")) {
@@ -168,12 +158,8 @@ export function describeSuspiciousRepoInput(repo: GitHubRepoRef): string | null 
     return "Owner segment matches a known web probe path."
   }
 
-  if (suspiciousRepoNames.has(name)) {
-    return "Repository segment matches a known web probe filename."
-  }
-
-  if (suspiciousRepoNamePattern.test(repo.name)) {
-    return "Repository segment looks like a probed file path instead of a repository name."
+  if (suspiciousRoutePairs.has(fullName)) {
+    return "Owner and repository pair matches a known web probe route."
   }
 
   return null

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -52,6 +52,9 @@ describe("assertWorkerRepoInputIsActionable", () => {
 
     await expect(assertWorkerRepoInputIsActionable("admin/.env")).rejects.toThrow("Queued input does not look like a GitHub repository")
     await expect(assertWorkerRepoInputIsActionable(".well-known/nodeinfo")).rejects.toThrow("Queued input does not look like a GitHub repository")
+    await expect(assertWorkerRepoInputIsActionable("wp-admin/admin-ajax.php")).rejects.toThrow(
+      "Queued input does not look like a GitHub repository",
+    )
 
     expect(fetchCalls).toEqual([])
   })
@@ -65,12 +68,33 @@ describe("assertWorkerRepoInputIsActionable", () => {
   })
 
   test("allows valid repositories through when GitHub resolves them", async () => {
-    globalThis.fetch = (async () => new Response(null, { status: 200 })) as unknown as typeof fetch
+    const fetchCalls: string[] = []
+    globalThis.fetch = (async (input: Request | string | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+      fetchCalls.push(url)
+      return new Response(null, { status: 200 })
+    }) as unknown as typeof fetch
 
     await expect(assertWorkerRepoInputIsActionable("openai/codex")).resolves.toMatchObject({
       fullName: "openai/codex",
       cloneUrl: "https://github.com/openai/codex.git",
     })
+
+    await expect(assertWorkerRepoInputIsActionable("github/.github")).resolves.toMatchObject({
+      fullName: "github/.github",
+      cloneUrl: "https://github.com/github/.github.git",
+    })
+
+    await expect(assertWorkerRepoInputIsActionable("vercel/next.js")).resolves.toMatchObject({
+      fullName: "vercel/next.js",
+      cloneUrl: "https://github.com/vercel/next.js.git",
+    })
+
+    expect(fetchCalls).toEqual([
+      "https://github.com/openai/codex",
+      "https://github.com/github/.github",
+      "https://github.com/vercel/next.js",
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary
- align worker suspicious-route validation with the narrowed web-side deny shape
- keep rejecting obvious probe routes before any network fetch while allowing legitimate dotted repos
- add worker regression coverage for blocked probe inputs and allowed dotted repositories

## Validation
- ✅ `npx bun test test/github.test.ts`
- ✅ `npx bun run typecheck`
- ✅ `cd web && npx bun run typecheck`
- ✅ `cd web && npx bun run build`
- ⚠️ `npx bun test` still fails in the existing `test/repository-service-page-view.test.ts` suite on the current base checkout; this diff does not touch that test or `web/src/lib/repository-service.ts`
- ✅ reviewer-only review-changes fallback via codex exec (`LGTM`) because full multi-reviewer orchestration was unavailable in this environment

Fixes #46
