### PR TITLE
Repository Index: add owner/repo search

### DIFF
--- a/.hermes/plans/2026-04-05-repo-index-search.md
+++ b/.hermes/plans/2026-04-05-repo-index-search.md
@@ -1,0 +1,37 @@
+# Repository Index: Add owner/repo search
+
+## Goal
+Add a shareable owner/repo text search to `/repos` so readers can find a repository quickly without losing the existing order, status, and pagination flow.
+
+## Why this improvement matters
+The repository index already contains more than a thousand rows. Paging and sort controls are not enough when someone wants one specific repository; search is the obvious missing capability and makes the index immediately more usable.
+
+## Current observations
+- `/repos` currently supports `page`, `order`, and `status` only.
+- `web/src/app/repos/page.tsx` and `web/src/app/api/repos/route.ts` each parse repository-list query params separately.
+- `web/src/lib/server/reports.ts:listRepoRecords()` already owns the shared list query path and is the right place to add a single SQL filter.
+- Existing pagination links do not preserve a search term because the feature does not exist yet.
+
+## Exact files to change
+- `web/src/lib/repository-list.ts`
+- `web/src/lib/server/reports.ts`
+- `web/src/app/api/repos/route.ts`
+- `web/src/app/repos/page.tsx`
+- `test/repo-list-search.test.ts`
+- `test/repos-api-route.test.ts`
+
+## Step-by-step implementation plan
+1. Extend the shared repository-list view shape to carry the normalized search query.
+2. Parse and normalize `query` in both the page route and `/api/repos`, and pass it through the existing list-loading flow.
+3. Add an escaped case-insensitive `full_name` SQL filter inside `listRepoRecords()` so search reuses the existing list query path.
+4. Add a GET-based search form to `/repos`, preserve `order` and `status`, and ensure next/previous links keep the query.
+5. Show a search-specific empty state when no repositories match.
+6. Add focused regression tests for the SQL/query propagation and route parsing.
+
+## Validation commands
+- `npx bun run typecheck`
+- `npx bun test`
+
+## Risks / rollback notes
+- The main risk is accidentally changing pagination or filter behavior when `query` is empty. Keep the filter additive and omit it entirely when the normalized query is blank.
+- If the SQL filter behaves unexpectedly, rollback is isolated to the repository-index files above.

--- a/test/repo-api-route.test.ts
+++ b/test/repo-api-route.test.ts
@@ -1,62 +1,87 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { describe, expect, test } from "bun:test"
 
-const repositoryServiceModulePath = new URL("../web/src/lib/repository-service.ts", import.meta.url).href
-const routeModulePath = new URL("../web/src/app/api/repo/[owner]/[repo]/route.ts", import.meta.url).href
+type ScriptResult<T> = {
+  code: number | null
+  stdout: T
+  stderr: string
+}
 
-class MockRepositoryNotFoundError extends Error {
-  constructor(fullName: string) {
-    super(`Repository not found on GitHub: ${fullName}`)
-    this.name = "RepositoryNotFoundError"
+function runBunScript<T>(script: string): ScriptResult<T> {
+  const result = spawnSync("npx", ["bun", "-e", script], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  })
+
+  return {
+    code: result.status,
+    stdout: JSON.parse(result.stdout || "null") as T,
+    stderr: result.stderr,
   }
 }
 
-let nextResult: unknown = null
-let shouldThrowNotFound = false
-
-mock.module(repositoryServiceModulePath, () => ({
-  RepositoryNotFoundError: MockRepositoryNotFoundError,
-  getRepositoryPageView: async (owner: string, repo: string) => {
-    if (shouldThrowNotFound) {
-      throw new MockRepositoryNotFoundError(`${owner}/${repo}`)
-    }
-
-    return nextResult
-  },
-}))
-
-const { GET } = await import(routeModulePath)
-
-beforeEach(() => {
-  shouldThrowNotFound = false
-  nextResult = {
-    kind: "queued",
-    fullName: "openai/codex",
-  }
-})
-
 describe("repo API route", () => {
-  test("returns a 404 payload when repository lookup rejects the route", async () => {
-    shouldThrowNotFound = true
+  test("returns a 404 payload when repository lookup rejects the route", () => {
+    const result = runBunScript<{ status: number; body: unknown }>(`
+      import { mock } from "bun:test"
+      const repositoryServiceModulePath = new URL("./web/src/lib/repository-service.ts", import.meta.url).href
+      const routeModulePath = new URL("./web/src/app/api/repo/[owner]/[repo]/route.ts", import.meta.url).href
+      class MockRepositoryNotFoundError extends Error {
+        constructor(fullName) {
+          super(\`Repository not found on GitHub: \${fullName}\`)
+          this.name = "RepositoryNotFoundError"
+        }
+      }
+      mock.module(repositoryServiceModulePath, () => ({
+        RepositoryNotFoundError: MockRepositoryNotFoundError,
+        getRepositoryPageView: async (owner, repo) => {
+          throw new MockRepositoryNotFoundError(\`\${owner}/\${repo}\`)
+        },
+      }))
+      const { GET } = await import(routeModulePath)
+      const response = await GET(new Request("https://discofork.ai/api/repo/admin/.env"), {
+        params: Promise.resolve({ owner: "admin", repo: ".env" }),
+      })
+      console.log(JSON.stringify({ status: response.status, body: await response.json() }))
+    `)
 
-    const response = await GET(new Request("https://discofork.ai/api/repo/admin/.env"), {
-      params: Promise.resolve({ owner: "admin", repo: ".env" }),
+    expect(result.code).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toEqual({
+      status: 404,
+      body: { error: "Repository not found." },
     })
-
-    expect(response.status).toBe(404)
-    expect(await response.json()).toEqual({ error: "Repository not found." })
   })
 
-  test("returns the repository payload for valid routes", async () => {
-    const response = await GET(new Request("https://discofork.ai/api/repo/openai/codex"), {
-      params: Promise.resolve({ owner: "openai", repo: "codex" }),
+  test("returns the repository payload for valid routes", () => {
+    const result = runBunScript<{ status: number; body: unknown }>(`
+      import { mock } from "bun:test"
+      const repositoryServiceModulePath = new URL("./web/src/lib/repository-service.ts", import.meta.url).href
+      const routeModulePath = new URL("./web/src/app/api/repo/[owner]/[repo]/route.ts", import.meta.url).href
+      const nextResult = {
+        kind: "queued",
+        fullName: "openai/codex",
+      }
+      class MockRepositoryNotFoundError extends Error {}
+      mock.module(repositoryServiceModulePath, () => ({
+        RepositoryNotFoundError: MockRepositoryNotFoundError,
+        getRepositoryPageView: async () => nextResult,
+      }))
+      const { GET } = await import(routeModulePath)
+      const response = await GET(new Request("https://discofork.ai/api/repo/openai/codex"), {
+        params: Promise.resolve({ owner: "openai", repo: "codex" }),
+      })
+      console.log(JSON.stringify({ status: response.status, body: await response.json() }))
+    `)
+
+    expect(result.code).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toEqual({
+      status: 200,
+      body: {
+        kind: "queued",
+        fullName: "openai/codex",
+      },
     })
-
-    expect(response.status).toBe(200)
-    expect(await response.json()).toEqual(nextResult)
   })
-})
-
-
-afterAll(() => {
-  mock.restore()
 })

--- a/test/repo-list-query.test.ts
+++ b/test/repo-list-query.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildRepoListHref,
+  normalizeRepoListQuery,
+  parseRepoListOrder,
+  parseRepoListPage,
+  parseRepoListStatusFilter,
+} from "../web/src/lib/repository-list-query"
+
+describe("repository list query helpers", () => {
+  test("normalizes page, order, status, and query values", () => {
+    expect(parseRepoListPage("4")).toBe(4)
+    expect(parseRepoListPage("0")).toBe(1)
+    expect(parseRepoListOrder("forks")).toBe("forks")
+    expect(parseRepoListOrder("bogus")).toBe("updated")
+    expect(parseRepoListStatusFilter("failed")).toBe("failed")
+    expect(parseRepoListStatusFilter("bogus")).toBe("all")
+    expect(normalizeRepoListQuery("  codex  ")).toBe("codex")
+  })
+
+  test("builds query-preserving /repos hrefs", () => {
+    expect(buildRepoListHref(4, "forks", "failed", "codex")).toBe("/repos?page=4&order=forks&status=failed&query=codex")
+    expect(buildRepoListHref(1, "updated", "all", "")).toBe("/repos?order=updated&status=all")
+  })
+})

--- a/test/repos-api-route.test.ts
+++ b/test/repos-api-route.test.ts
@@ -1,0 +1,182 @@
+import { spawnSync } from "node:child_process"
+import { describe, expect, test } from "bun:test"
+
+type ScriptResult<T> = {
+  code: number | null
+  stdout: T
+  stderr: string
+}
+
+function runBunScript<T>(script: string): ScriptResult<T> {
+  const result = spawnSync("npx", ["bun", "-e", script], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  })
+
+  return {
+    code: result.status,
+    stdout: JSON.parse(result.stdout || "null") as T,
+    stderr: result.stderr,
+  }
+}
+
+describe("repos API route", () => {
+  test("passes normalized query params through to listRepoRecords and the JSON payload", () => {
+    const result = runBunScript<{
+      calls: Array<[number, number, string, string, string]>
+      status: number
+      body: unknown
+    }>(`
+      import { mock } from "bun:test"
+      const databaseModulePath = new URL("./web/src/lib/server/database.ts", import.meta.url).href
+      const queueModulePath = new URL("./web/src/lib/server/queue.ts", import.meta.url).href
+      const reportsModulePath = new URL("./web/src/lib/server/reports.ts", import.meta.url).href
+      const routeModulePath = new URL("./web/src/app/api/repos/route.ts", import.meta.url).href
+      const calls = []
+      mock.module(databaseModulePath, () => ({ databaseConfigured: () => true }))
+      mock.module(queueModulePath, () => ({ queueConfigured: () => true }))
+      mock.module(reportsModulePath, () => ({
+        listRepoRecords: async (...args) => {
+          calls.push(args)
+          return {
+            items: [{
+              full_name: "openai/codex",
+              owner: "openai",
+              repo: "codex",
+              github_url: "https://github.com/openai/codex",
+              status: "ready",
+              queued_at: null,
+              processing_started_at: null,
+              cached_at: "2026-04-10T22:00:00Z",
+              updated_at: "2026-04-10T22:00:00Z",
+              retry_count: 0,
+              retry_state: "none",
+              next_retry_at: null,
+              last_failed_at: null,
+              stars: 123,
+              forks: 45,
+              default_branch: "main",
+              last_pushed_at: "2026-04-10T21:00:00Z",
+              upstream_summary: "Codex summary",
+              fork_brief_count: 2,
+            }],
+            stats: {
+              total: 10,
+              queued: 1,
+              processing: 2,
+              pending: 3,
+              cached: 7,
+              failed: 1,
+            },
+            total: 1,
+          }
+        },
+      }))
+      const { GET } = await import(routeModulePath)
+      const response = await GET({ nextUrl: new URL("https://discofork.ai/api/repos?page=4&order=forks&status=failed&query=%20codex%20") })
+      console.log(JSON.stringify({ calls, status: response.status, body: await response.json() }))
+    `)
+
+    expect(result.code).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toEqual({
+      calls: [[4, 25, "forks", "failed", "codex"]],
+      status: 200,
+      body: {
+        items: [
+          {
+            fullName: "openai/codex",
+            owner: "openai",
+            repo: "codex",
+            githubUrl: "https://github.com/openai/codex",
+            status: "ready",
+            queuedAt: null,
+            processingStartedAt: null,
+            cachedAt: "2026-04-10T22:00:00Z",
+            updatedAt: "2026-04-10T22:00:00Z",
+            retryCount: 0,
+            retryState: "none",
+            nextRetryAt: null,
+            lastFailedAt: null,
+            stars: 123,
+            forks: 45,
+            defaultBranch: "main",
+            lastPushedAt: "2026-04-10T21:00:00Z",
+            upstreamSummary: "Codex summary",
+            forkBriefCount: 2,
+          },
+        ],
+        stats: {
+          total: 10,
+          queued: 1,
+          processing: 2,
+          pending: 3,
+          cached: 7,
+          failed: 1,
+        },
+        order: "forks",
+        statusFilter: "failed",
+        query: "codex",
+        page: 4,
+        pageSize: 25,
+        total: 1,
+        totalPages: 1,
+        hasPrevious: true,
+        hasNext: false,
+        databaseEnabled: true,
+        queueEnabled: true,
+      },
+    })
+  })
+
+  test("returns an empty disabled-database payload with a normalized blank query", () => {
+    const result = runBunScript<{ calls: unknown[]; status: number; body: unknown }>(`
+      import { mock } from "bun:test"
+      const databaseModulePath = new URL("./web/src/lib/server/database.ts", import.meta.url).href
+      const queueModulePath = new URL("./web/src/lib/server/queue.ts", import.meta.url).href
+      const reportsModulePath = new URL("./web/src/lib/server/reports.ts", import.meta.url).href
+      const routeModulePath = new URL("./web/src/app/api/repos/route.ts", import.meta.url).href
+      const calls = []
+      mock.module(databaseModulePath, () => ({ databaseConfigured: () => false }))
+      mock.module(queueModulePath, () => ({ queueConfigured: () => true }))
+      mock.module(reportsModulePath, () => ({
+        listRepoRecords: async (...args) => {
+          calls.push(args)
+          return { items: [], stats: { total: 0, queued: 0, processing: 0, pending: 0, cached: 0, failed: 0 }, total: 0 }
+        },
+      }))
+      const { GET } = await import(routeModulePath)
+      const response = await GET({ nextUrl: new URL("https://discofork.ai/api/repos?page=2&query=%20%20") })
+      console.log(JSON.stringify({ calls, status: response.status, body: await response.json() }))
+    `)
+
+    expect(result.code).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toEqual({
+      calls: [],
+      status: 200,
+      body: {
+        items: [],
+        stats: {
+          total: 0,
+          queued: 0,
+          processing: 0,
+          pending: 0,
+          cached: 0,
+          failed: 0,
+        },
+        order: "updated",
+        statusFilter: "all",
+        query: "",
+        page: 2,
+        pageSize: 25,
+        total: 0,
+        totalPages: 0,
+        hasPrevious: true,
+        hasNext: false,
+        databaseEnabled: false,
+        queueEnabled: true,
+      },
+    })
+  })
+})

--- a/test/repository-list-filter.test.ts
+++ b/test/repository-list-filter.test.ts
@@ -21,30 +21,36 @@ function runBunScript<T>(script: string): ScriptResult<T> {
 }
 
 describe("repository list filtering", () => {
-  test("buildRepoListWhereClause excludes suspicious rows and composes status filters", () => {
-    const result = runBunScript<{ whereAll: string; whereFailed: string }>(`
+  test("buildRepoListWhereClause excludes suspicious rows and composes status and search filters", () => {
+    const result = runBunScript<{
+      whereAll: { clause: string; params: unknown[] }
+      whereFailed: { clause: string; params: unknown[] }
+    }>(`
       import { mock } from "bun:test"
       const databaseModulePath = new URL("./web/src/lib/server/database.ts", import.meta.url).href
       mock.module(databaseModulePath, () => ({ query: async () => [] }))
       const { buildRepoListWhereClause } = await import(new URL("./web/src/lib/server/reports.ts", import.meta.url).href)
       console.log(JSON.stringify({
         whereAll: buildRepoListWhereClause("all"),
-        whereFailed: buildRepoListWhereClause("failed"),
+        whereFailed: buildRepoListWhereClause("failed", "cli_go%"),
       }))
     `)
 
     expect(result.code).toBe(0)
     expect(result.stderr).toBe("")
-    expect(result.stdout.whereAll).toContain("not (")
-    expect(result.stdout.whereAll).toContain("lower(owner) in ('.well-known')")
-    expect(result.stdout.whereAll).toContain("lower(owner || '/' || repo) in ('admin/.env', 'wp-admin/admin-ajax.php')")
-    expect(result.stdout.whereAll).toContain("position('/' in repo) > 0")
-    expect(result.stdout.whereAll).not.toContain("lower(repo) in")
-    expect(result.stdout.whereAll).not.toContain("status =")
-    expect(result.stdout.whereFailed).toContain("status = 'failed'")
+    expect(result.stdout.whereAll.clause).toContain("not (")
+    expect(result.stdout.whereAll.clause).toContain("lower(owner) in ('.well-known')")
+    expect(result.stdout.whereAll.clause).toContain("lower(owner || '/' || repo) in ('admin/.env', 'wp-admin/admin-ajax.php')")
+    expect(result.stdout.whereAll.clause).toContain("position('/' in repo) > 0")
+    expect(result.stdout.whereAll.clause).not.toContain("lower(repo) in")
+    expect(result.stdout.whereAll.clause).not.toContain("status =")
+    expect(result.stdout.whereAll.params).toEqual([])
+    expect(result.stdout.whereFailed.clause).toContain("status = $1")
+    expect(result.stdout.whereFailed.clause).toContain("full_name ilike $2 escape")
+    expect(result.stdout.whereFailed.params).toEqual(["failed", "%cli\\_go\\%%"])
   })
 
-  test("listRepoRecords applies suspicious-row filtering to stats, totals, and item queries", () => {
+  test("listRepoRecords applies suspicious-row filtering to stats, totals, and item queries while preserving global stats", () => {
     const result = runBunScript<Array<{ sql: string; params: unknown[] }>>(`
       import { mock } from "bun:test"
       const databaseModulePath = new URL("./web/src/lib/server/database.ts", import.meta.url).href
@@ -62,19 +68,29 @@ describe("repository list filtering", () => {
         },
       }))
       const { listRepoRecords } = await import(new URL("./web/src/lib/server/reports.ts", import.meta.url).href)
-      await listRepoRecords(1, 20, "updated", "failed")
+      await listRepoRecords(1, 20, "updated", "failed", "codex")
       console.log(JSON.stringify(queryCalls))
     `)
 
     expect(result.code).toBe(0)
     expect(result.stderr).toBe("")
     expect(result.stdout).toHaveLength(3)
+
     expect(result.stdout[0]?.sql).toContain("not (")
-    expect(result.stdout[0]?.sql).not.toContain("and status = 'failed'")
-    expect(result.stdout[0]?.sql).not.toContain("lower(repo) in")
+    expect(result.stdout[0]?.sql).not.toContain("status = $1")
+    expect(result.stdout[0]?.sql).not.toContain("full_name ilike")
+    expect(result.stdout[0]?.params).toEqual([])
+
     expect(result.stdout[1]?.sql).toContain("not (")
-    expect(result.stdout[1]?.sql).toContain("status = 'failed'")
+    expect(result.stdout[1]?.sql).toContain("status = $1")
+    expect(result.stdout[1]?.sql).toContain("full_name ilike $2 escape")
+    expect(result.stdout[1]?.params).toEqual(["failed", "%codex%"])
+
     expect(result.stdout[2]?.sql).toContain("not (")
-    expect(result.stdout[2]?.sql).toContain("status = 'failed'")
+    expect(result.stdout[2]?.sql).toContain("status = $1")
+    expect(result.stdout[2]?.sql).toContain("full_name ilike $2 escape")
+    expect(result.stdout[2]?.sql).toContain("limit $3")
+    expect(result.stdout[2]?.sql).toContain("offset $4")
+    expect(result.stdout[2]?.params).toEqual(["failed", "%codex%", 20, 0])
   })
 })

--- a/test/repository-service-page-view.test.ts
+++ b/test/repository-service-page-view.test.ts
@@ -21,62 +21,73 @@ let queueEnabled = true
 let repoRecord: any = null
 let statusSnapshot: any = null
 let fetchStatus = 200
+let repositoryServiceImportVersion = 0
 
-mock.module(databaseModulePath, () => ({
-  databaseConfigured: () => databaseEnabled,
-}))
+let RepositoryNotFoundError: typeof Error
+let getRepositoryPageView: (owner: string, repo: string) => Promise<any>
+let readRepositoryView: (owner: string, repo: string) => Promise<any>
 
-mock.module(liveStatusModulePath, () => ({
-  getRepoStatusSnapshot: async () => statusSnapshot,
-}))
+function applyRepositoryServiceMocks() {
+  mock.module(databaseModulePath, () => ({
+    databaseConfigured: () => databaseEnabled,
+  }))
 
-mock.module(queueModulePath, () => ({
-  enqueueRepoJob: async (fullName: string) => {
-    enqueueCalls.push(fullName)
-    return true
-  },
-  getRedisClient: async () => ({ get: async () => null, set: async () => "OK" }) as unknown,
-  queueConfigured: () => queueEnabled,
-}))
+  mock.module(liveStatusModulePath, () => ({
+    getRepoStatusSnapshot: async () => statusSnapshot,
+  }))
 
-mock.module(reportsModulePath, () => ({
-  getRepoRecord: async (fullName: string) => {
-    repoRecordLookups.push(fullName)
-    return repoRecord
-  },
-  touchQueuedRepo: async (owner: string, repo: string, queuedNow: boolean) => {
-    touchCalls.push({ owner, repo, queuedNow })
-    repoRecord = {
-      full_name: `${owner}/${repo}`,
-      owner,
-      repo,
-      github_url: `https://github.com/${owner}/${repo}`,
-      status: "queued",
-      report_json: null,
-      error_message: null,
-      last_requested_at: "2026-04-04T00:00:00Z",
-      queued_at: "2026-04-04T00:00:00Z",
-      processing_started_at: null,
-      cached_at: null,
-      created_at: "2026-04-04T00:00:00Z",
-      updated_at: "2026-04-04T00:00:00Z",
-    }
-    statusSnapshot = {
-      status: "queued",
-      queuePosition: 1,
-      progress: null,
-      errorMessage: null,
-      queuedAt: "2026-04-04T00:00:00Z",
-      processingStartedAt: null,
-      cachedAt: null,
-    }
-  },
-}))
+  mock.module(queueModulePath, () => ({
+    enqueueRepoJob: async (fullName: string) => {
+      enqueueCalls.push(fullName)
+      return true
+    },
+    getRedisClient: async () => ({ get: async () => null, set: async () => "OK" }) as unknown,
+    queueConfigured: () => queueEnabled,
+  }))
 
-const { RepositoryNotFoundError, getRepositoryPageView, readRepositoryView } = await import(repositoryServiceModulePath)
+  mock.module(reportsModulePath, () => ({
+    getRepoRecord: async (fullName: string) => {
+      repoRecordLookups.push(fullName)
+      return repoRecord
+    },
+    touchQueuedRepo: async (owner: string, repo: string, queuedNow: boolean) => {
+      touchCalls.push({ owner, repo, queuedNow })
+      repoRecord = {
+        full_name: `${owner}/${repo}`,
+        owner,
+        repo,
+        github_url: `https://github.com/${owner}/${repo}`,
+        status: "queued",
+        report_json: null,
+        error_message: null,
+        last_requested_at: "2026-04-04T00:00:00Z",
+        queued_at: "2026-04-04T00:00:00Z",
+        processing_started_at: null,
+        cached_at: null,
+        created_at: "2026-04-04T00:00:00Z",
+        updated_at: "2026-04-04T00:00:00Z",
+      }
+      statusSnapshot = {
+        status: "queued",
+        queuePosition: 1,
+        progress: null,
+        errorMessage: null,
+        queuedAt: "2026-04-04T00:00:00Z",
+        processingStartedAt: null,
+        cachedAt: null,
+      }
+    },
+  }))
+}
+
+async function loadRepositoryServiceModule() {
+  repositoryServiceImportVersion += 1
+  return import(`${repositoryServiceModulePath}?repository-service-test=${repositoryServiceImportVersion}`)
+}
+
 const originalFetch = globalThis.fetch
 
-beforeEach(() => {
+beforeEach(async () => {
   databaseEnabled = true
   queueEnabled = true
   repoRecord = null
@@ -95,6 +106,12 @@ beforeEach(() => {
     fetchCalls.push(url)
     return new Response(null, { status: fetchStatus })
   }) as typeof fetch
+
+  applyRepositoryServiceMocks()
+  const repositoryServiceModule = await loadRepositoryServiceModule()
+  RepositoryNotFoundError = repositoryServiceModule.RepositoryNotFoundError
+  getRepositoryPageView = repositoryServiceModule.getRepositoryPageView
+  readRepositoryView = repositoryServiceModule.readRepositoryView
 })
 
 afterEach(() => {
@@ -127,7 +144,7 @@ describe("repository page view loading", () => {
   })
 
   test("rejects suspicious page routes before stored lookups, fetches, or queue mutations", async () => {
-    process.env.GH_TOKEN = "test-token"
+    process.env.GH_TOKEN = "***"
 
     await expect(getRepositoryPageView("admin", ".env")).rejects.toBeInstanceOf(RepositoryNotFoundError)
 
@@ -138,7 +155,7 @@ describe("repository page view loading", () => {
   })
 
   test("rejects suspicious read-only routes before stored lookup side effects", async () => {
-    process.env.GH_TOKEN = "test-token"
+    process.env.GH_TOKEN = "***"
     repoRecord = {
       full_name: ".well-known/nodeinfo",
       owner: ".well-known",
@@ -163,7 +180,6 @@ describe("repository page view loading", () => {
     expect(fetchCalls).toEqual([])
   })
 })
-
 
 afterAll(() => {
   mock.restore()

--- a/web/src/app/api/repos/route.ts
+++ b/web/src/app/api/repos/route.ts
@@ -1,38 +1,19 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import {
-  REPO_LIST_ORDER_VALUES,
   REPO_LIST_PAGE_SIZE,
-  REPO_LIST_STATUS_FILTER_VALUES,
-  type RepoListOrder,
-  type RepoListStatusFilter,
   type RepoListView,
 } from "@/lib/repository-list"
+import { normalizeRepoListQuery, parseRepoListOrder, parseRepoListPage, parseRepoListStatusFilter } from "@/lib/repository-list-query"
 import { databaseConfigured } from "@/lib/server/database"
 import { queueConfigured } from "@/lib/server/queue"
 import { listRepoRecords } from "@/lib/server/reports"
 
-function parsePage(rawValue: string | null): number {
-  const parsed = Number.parseInt(rawValue ?? "1", 10)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
-}
-
-function parseOrder(rawValue: string | null): RepoListOrder {
-  return REPO_LIST_ORDER_VALUES.includes((rawValue ?? "") as RepoListOrder)
-    ? ((rawValue ?? "updated") as RepoListOrder)
-    : "updated"
-}
-
-function parseStatusFilter(rawValue: string | null): RepoListStatusFilter {
-  return REPO_LIST_STATUS_FILTER_VALUES.includes((rawValue ?? "") as RepoListStatusFilter)
-    ? ((rawValue ?? "all") as RepoListStatusFilter)
-    : "all"
-}
-
 export async function GET(request: NextRequest) {
-  const page = parsePage(request.nextUrl.searchParams.get("page"))
-  const order = parseOrder(request.nextUrl.searchParams.get("order"))
-  const statusFilter = parseStatusFilter(request.nextUrl.searchParams.get("status"))
+  const page = parseRepoListPage(request.nextUrl.searchParams.get("page"))
+  const order = parseRepoListOrder(request.nextUrl.searchParams.get("order"))
+  const statusFilter = parseRepoListStatusFilter(request.nextUrl.searchParams.get("status"))
+  const query = normalizeRepoListQuery(request.nextUrl.searchParams.get("query"))
 
   if (!databaseConfigured()) {
     const payload: RepoListView = {
@@ -47,6 +28,7 @@ export async function GET(request: NextRequest) {
       },
       order,
       statusFilter,
+      query,
       page,
       pageSize: REPO_LIST_PAGE_SIZE,
       total: 0,
@@ -60,7 +42,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(payload)
   }
 
-  const { items, stats, total } = await listRepoRecords(page, REPO_LIST_PAGE_SIZE, order, statusFilter)
+  const { items, stats, total } = await listRepoRecords(page, REPO_LIST_PAGE_SIZE, order, statusFilter, query)
   const totalPages = total === 0 ? 0 : Math.ceil(total / REPO_LIST_PAGE_SIZE)
 
   const payload: RepoListView = {
@@ -88,6 +70,7 @@ export async function GET(request: NextRequest) {
     stats,
     order,
     statusFilter,
+    query,
     page,
     pageSize: REPO_LIST_PAGE_SIZE,
     total,

--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import Link from "next/link"
-import { ArrowRight, Database, GitFork, Star } from "lucide-react"
+import { ArrowRight, Database, GitFork, Search, Star } from "lucide-react"
 
 import { RepoOrderSelect } from "@/components/repo-order-select"
 import { RepoStatusFilter } from "@/components/repo-status-filter"
@@ -8,6 +8,7 @@ import { RepoShell } from "@/components/repo-shell"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
 import { REPO_LIST_PAGE_SIZE, type RepoListItem, type RepoListOrder, type RepoListStatusFilter, type RepoListView } from "@/lib/repository-list"
+import { buildRepoListHref, normalizeRepoListQuery, parseRepoListOrder, parseRepoListPage, parseRepoListStatusFilter } from "@/lib/repository-list-query"
 import { databaseConfigured } from "@/lib/server/database"
 import { queueConfigured } from "@/lib/server/queue"
 import { listRepoRecords } from "@/lib/server/reports"
@@ -18,39 +19,13 @@ type RepoIndexPageProps = {
     page?: string
     order?: string
     status?: string
+    query?: string
   }>
 }
 
 export const metadata: Metadata = {
   title: "Repository Index · Discofork",
   description: "Browse cached and queued Discofork repository briefs.",
-}
-
-function parsePage(rawValue: string | undefined): number {
-  const parsed = Number.parseInt(rawValue ?? "1", 10)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
-}
-
-function parseOrder(rawValue: string | undefined): RepoListOrder {
-  switch (rawValue) {
-    case "forks":
-    case "stars":
-      return rawValue
-    default:
-      return "updated"
-  }
-}
-
-function parseStatusFilter(rawValue: string | undefined): RepoListStatusFilter {
-  switch (rawValue) {
-    case "queued":
-    case "ready":
-    case "processing":
-    case "failed":
-      return rawValue
-    default:
-      return "all"
-  }
 }
 
 function formatDate(value: string | null): string {
@@ -105,7 +80,12 @@ function statusTimestampLabel(item: RepoListItem): string {
   }
 }
 
-async function loadRepositoryListView(page: number, order: RepoListOrder, statusFilter: RepoListStatusFilter): Promise<RepoListView> {
+async function loadRepositoryListView(
+  page: number,
+  order: RepoListOrder,
+  statusFilter: RepoListStatusFilter,
+  query: string,
+): Promise<RepoListView> {
   if (!databaseConfigured()) {
     return {
       items: [],
@@ -119,6 +99,7 @@ async function loadRepositoryListView(page: number, order: RepoListOrder, status
       },
       order,
       statusFilter,
+      query,
       page,
       pageSize: REPO_LIST_PAGE_SIZE,
       total: 0,
@@ -130,7 +111,7 @@ async function loadRepositoryListView(page: number, order: RepoListOrder, status
     }
   }
 
-  const { items, stats, total } = await listRepoRecords(page, REPO_LIST_PAGE_SIZE, order, statusFilter)
+  const { items, stats, total } = await listRepoRecords(page, REPO_LIST_PAGE_SIZE, order, statusFilter, query)
   const totalPages = total === 0 ? 0 : Math.ceil(total / REPO_LIST_PAGE_SIZE)
 
   return {
@@ -158,6 +139,7 @@ async function loadRepositoryListView(page: number, order: RepoListOrder, status
     stats,
     order,
     statusFilter,
+    query,
     page,
     pageSize: REPO_LIST_PAGE_SIZE,
     total,
@@ -171,16 +153,18 @@ async function loadRepositoryListView(page: number, order: RepoListOrder, status
 
 export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
   const resolvedSearchParams = await searchParams
-  const page = parsePage(resolvedSearchParams?.page)
-  const order = parseOrder(resolvedSearchParams?.order)
-  const statusFilter = parseStatusFilter(resolvedSearchParams?.status)
-  const view = await loadRepositoryListView(page, order, statusFilter)
+  const page = parseRepoListPage(resolvedSearchParams?.page)
+  const order = parseRepoListOrder(resolvedSearchParams?.order)
+  const statusFilter = parseRepoListStatusFilter(resolvedSearchParams?.status)
+  const query = normalizeRepoListQuery(resolvedSearchParams?.query)
+  const view = await loadRepositoryListView(page, order, statusFilter, query)
   const previousHref = view.hasPrevious
-    ? `/repos?page=${view.page - 1}&order=${view.order}&status=${view.statusFilter}`
-    : `/repos?order=${view.order}&status=${view.statusFilter}`
+    ? buildRepoListHref(view.page - 1, view.order, view.statusFilter, view.query)
+    : buildRepoListHref(1, view.order, view.statusFilter, view.query)
   const nextHref = view.hasNext
-    ? `/repos?page=${view.page + 1}&order=${view.order}&status=${view.statusFilter}`
-    : `/repos?page=${view.page}&order=${view.order}&status=${view.statusFilter}`
+    ? buildRepoListHref(view.page + 1, view.order, view.statusFilter, view.query)
+    : buildRepoListHref(view.page, view.order, view.statusFilter, view.query)
+  const clearSearchHref = buildRepoListHref(1, view.order, view.statusFilter, "")
 
   return (
     <RepoShell
@@ -190,42 +174,80 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
       compact
     >
       <section className="space-y-6">
-        <div className="flex flex-wrap items-center justify-between gap-4 rounded-md border border-border bg-card px-5 py-4">
-          <div className="flex flex-wrap items-center gap-5 text-sm text-muted-foreground">
-            <div className="flex items-center gap-2">
-              <Database className="h-4 w-4 text-muted-foreground" />
-              <span>{view.total.toLocaleString()} repos</span>
+        <div className="space-y-4 rounded-md border border-border bg-card px-5 py-4">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex flex-wrap items-center gap-5 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <Database className="h-4 w-4 text-muted-foreground" />
+                <span>{view.total.toLocaleString()} {view.query ? "matching repos" : "repos"}</span>
+              </div>
+              <div>Page {view.totalPages === 0 ? 0 : view.page} of {view.totalPages}</div>
+              <div>{view.pageSize} repos per page</div>
+              {view.stats.failed > 0 ? <div>{view.stats.failed.toLocaleString()} failed</div> : null}
             </div>
-            <div>Page {view.totalPages === 0 ? 0 : view.page} of {view.totalPages}</div>
-            <div>{view.pageSize} repos per page</div>
-            {view.stats.failed > 0 ? <div>{view.stats.failed.toLocaleString()} failed</div> : null}
+
+            {view.query ? (
+              <div className="rounded-full border border-border bg-muted/70 px-3 py-1 text-xs text-muted-foreground">
+                Matching “{view.query}”
+              </div>
+            ) : null}
           </div>
 
           <div className="flex flex-wrap items-start gap-2">
-            <RepoOrderSelect value={view.order} />
-            <RepoStatusFilter value={view.statusFilter} />
-            <Link
-              href={previousHref}
-              aria-disabled={!view.hasPrevious}
-              className={cn(
-                buttonVariants({ variant: "outline" }),
-                "rounded-md px-4",
-                !view.hasPrevious && "pointer-events-none opacity-50",
-              )}
-            >
-              Previous
-            </Link>
-            <Link
-              href={nextHref}
-              aria-disabled={!view.hasNext}
-              className={cn(
-                buttonVariants({ variant: "outline" }),
-                "rounded-md px-4",
-                !view.hasNext && "pointer-events-none opacity-50",
-              )}
-            >
-              Next
-            </Link>
+            <form action="/repos" className="flex min-w-[280px] flex-1 flex-wrap items-center gap-2">
+              <label htmlFor="repo-query" className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+                Search
+              </label>
+              <div className="relative min-w-[240px] flex-1">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  id="repo-query"
+                  type="search"
+                  name="query"
+                  defaultValue={view.query}
+                  placeholder="owner/repo or partial name"
+                  autoComplete="off"
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 pl-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+                />
+              </div>
+              <input type="hidden" name="order" value={view.order} />
+              <input type="hidden" name="status" value={view.statusFilter} />
+              <button type="submit" className={cn(buttonVariants({ variant: "outline" }), "rounded-md px-4")}>
+                Search
+              </button>
+              {view.query ? (
+                <Link href={clearSearchHref} className={cn(buttonVariants({ variant: "ghost" }), "rounded-md px-4")}>
+                  Clear
+                </Link>
+              ) : null}
+            </form>
+
+            <div className="flex flex-wrap items-start gap-2">
+              <RepoOrderSelect value={view.order} />
+              <RepoStatusFilter value={view.statusFilter} />
+              <Link
+                href={previousHref}
+                aria-disabled={!view.hasPrevious}
+                className={cn(
+                  buttonVariants({ variant: "outline" }),
+                  "rounded-md px-4",
+                  !view.hasPrevious && "pointer-events-none opacity-50",
+                )}
+              >
+                Previous
+              </Link>
+              <Link
+                href={nextHref}
+                aria-disabled={!view.hasNext}
+                className={cn(
+                  buttonVariants({ variant: "outline" }),
+                  "rounded-md px-4",
+                  !view.hasNext && "pointer-events-none opacity-50",
+                )}
+              >
+                Next
+              </Link>
+            </div>
           </div>
         </div>
 
@@ -235,7 +257,13 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
           </div>
         ) : view.items.length === 0 ? (
           <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
-            No repositories have been indexed yet.
+            {view.query ? (
+              <>
+                No repositories match <span className="font-medium text-foreground">“{view.query}”</span>. Try a broader owner or repo name, or clear the search.
+              </>
+            ) : (
+              "No repositories have been indexed yet."
+            )}
           </div>
         ) : (
           <div className="overflow-hidden rounded-md border border-border bg-card">

--- a/web/src/lib/repository-list-api.ts
+++ b/web/src/lib/repository-list-api.ts
@@ -1,11 +1,13 @@
 import { headers } from "next/headers"
 
 import type { RepoListOrder, RepoListStatusFilter, RepoListView } from "./repository-list"
+import { normalizeRepoListQuery } from "./repository-list-query"
 
 export async function fetchRepositoryList(
   page: number,
   order: RepoListOrder,
   statusFilter: RepoListStatusFilter,
+  query = "",
 ): Promise<RepoListView> {
   const headerStore = await headers()
   const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host")
@@ -15,7 +17,17 @@ export async function fetchRepositoryList(
     throw new Error("Could not determine request host for repository index lookup.")
   }
 
-  const response = await fetch(`${proto}://${host}/api/repos?page=${page}&order=${order}&status=${statusFilter}`, {
+  const params = new URLSearchParams({
+    page: String(page),
+    order,
+    status: statusFilter,
+  })
+  const normalizedQuery = normalizeRepoListQuery(query)
+  if (normalizedQuery) {
+    params.set("query", normalizedQuery)
+  }
+
+  const response = await fetch(`${proto}://${host}/api/repos?${params.toString()}`, {
     cache: "no-store",
   })
 

--- a/web/src/lib/repository-list-query.ts
+++ b/web/src/lib/repository-list-query.ts
@@ -1,0 +1,39 @@
+import { REPO_LIST_ORDER_VALUES, REPO_LIST_STATUS_FILTER_VALUES, type RepoListOrder, type RepoListStatusFilter } from "./repository-list"
+
+export function parseRepoListPage(rawValue: string | null | undefined): number {
+  const parsed = Number.parseInt(rawValue ?? "1", 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
+}
+
+export function parseRepoListOrder(rawValue: string | null | undefined): RepoListOrder {
+  return REPO_LIST_ORDER_VALUES.includes((rawValue ?? "") as RepoListOrder)
+    ? ((rawValue ?? "updated") as RepoListOrder)
+    : "updated"
+}
+
+export function parseRepoListStatusFilter(rawValue: string | null | undefined): RepoListStatusFilter {
+  return REPO_LIST_STATUS_FILTER_VALUES.includes((rawValue ?? "") as RepoListStatusFilter)
+    ? ((rawValue ?? "all") as RepoListStatusFilter)
+    : "all"
+}
+
+export function normalizeRepoListQuery(rawValue: string | null | undefined): string {
+  return rawValue?.trim() ?? ""
+}
+
+export function buildRepoListHref(page: number, order: RepoListOrder, statusFilter: RepoListStatusFilter, query: string): string {
+  const params = new URLSearchParams()
+
+  if (page > 1) {
+    params.set("page", String(page))
+  }
+
+  params.set("order", order)
+  params.set("status", statusFilter)
+
+  if (query) {
+    params.set("query", query)
+  }
+
+  return `/repos?${params.toString()}`
+}

--- a/web/src/lib/repository-list.ts
+++ b/web/src/lib/repository-list.ts
@@ -44,6 +44,7 @@ export type RepoListView = {
   stats: RepoListStats
   order: RepoListOrder
   statusFilter: RepoListStatusFilter
+  query: string
   page: number
   pageSize: number
   total: number

--- a/web/src/lib/server/reports.ts
+++ b/web/src/lib/server/reports.ts
@@ -127,14 +127,32 @@ export async function touchQueuedRepo(owner: string, repo: string, queuedNow: bo
   )
 }
 
-export function buildRepoListWhereClause(statusFilter: RepoListStatusFilter): string {
+export function escapeRepoListQuery(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")
+}
+
+export function buildRepoListWhereClause(
+  statusFilter: RepoListStatusFilter,
+  queryText = "",
+): { clause: string; params: unknown[] } {
   const clauses = [`not (${SUSPICIOUS_REPOSITORY_ROUTE_SQL_PREDICATE})`]
+  const params: unknown[] = []
+  const normalizedQueryText = queryText.trim()
 
   if (statusFilter !== "all") {
-    clauses.push(`status = '${statusFilter}'`)
+    params.push(statusFilter)
+    clauses.push(`status = $${params.length}`)
   }
 
-  return `where ${clauses.join(" and ")}`
+  if (normalizedQueryText) {
+    params.push(`%${escapeRepoListQuery(normalizedQueryText)}%`)
+    clauses.push(`full_name ilike $${params.length} escape '\\'`)
+  }
+
+  return {
+    clause: `where ${clauses.join(" and ")}`,
+    params,
+  }
 }
 
 export async function listRepoRecords(
@@ -142,12 +160,13 @@ export async function listRepoRecords(
   pageSize: number,
   order: RepoListOrder,
   statusFilter: RepoListStatusFilter,
+  queryText = "",
 ): Promise<{ items: StoredRepoListRecord[]; stats: RepoListStatsRecord; total: number }> {
   const safePage = Math.max(1, page)
   const safePageSize = Math.max(1, pageSize)
   const offset = (safePage - 1) * safePageSize
   const baseWhereClause = buildRepoListWhereClause("all")
-  const listWhereClause = buildRepoListWhereClause(statusFilter)
+  const listWhereClause = buildRepoListWhereClause(statusFilter, queryText)
   const orderByClause =
     order === "forks"
       ? "coalesce(nullif(report_json->'upstream'->'metadata'->>'forkCount', '')::int, -1) desc, updated_at desc, full_name asc"
@@ -164,7 +183,7 @@ export async function listRepoRecords(
       count(*) filter (where status = 'ready')::int as cached,
       count(*) filter (where status = 'failed')::int as failed
     from repo_reports
-    ${baseWhereClause}`,
+    ${baseWhereClause.clause}`,
   )
   const stats = statRows[0] ?? {
     total: 0,
@@ -178,10 +197,12 @@ export async function listRepoRecords(
   const totalRows = await query<{ count: string }>(
     `select count(*)::text as count
     from repo_reports
-    ${listWhereClause}`,
+    ${listWhereClause.clause}`,
+    listWhereClause.params,
   )
   const total = Number.parseInt(totalRows[0]?.count ?? "0", 10)
 
+  const itemParams = [...listWhereClause.params, safePageSize, offset]
   const items = await query<StoredRepoListRecord>(
     `select
       full_name,
@@ -204,11 +225,11 @@ export async function listRepoRecords(
       report_json->'upstream'->'analysis'->>'summary' as upstream_summary,
       coalesce(jsonb_array_length(coalesce(report_json->'forks', '[]'::jsonb)), 0) as fork_brief_count
     from repo_reports
-    ${listWhereClause}
+    ${listWhereClause.clause}
     order by ${orderByClause}
-    limit $1
-    offset $2`,
-    [safePageSize, offset],
+    limit $${itemParams.length - 1}
+    offset $${itemParams.length}`,
+    itemParams,
   )
 
   return { items, stats, total }


### PR DESCRIPTION
Closes #33

## Summary
- add a shareable owner/repo search query to `/repos` and `/api/repos`
- preserve `order`, `status`, and pagination state while resetting search submissions back to page 1
- add focused regression coverage for query parsing, SQL filtering, route payloads, and route-test isolation

## Why this improves Discofork
The repository index has grown beyond manual paging. This gives operators a fast, URL-shareable way to jump straight to the repo they care about without losing the existing status/order controls.

## Validation
- `npx bun run typecheck`
- `npx bun test`
- `cd web && npx bun run typecheck`
- `cd web && npx bun run build`

## Risks / follow-ups
- Pre-commit review used reviewer-only fallback because the full `review-changes` orchestration path was unavailable in this run.
- The reviewer surfaced a potential search-index follow-up for larger datasets; this PR keeps scope to the user-facing search flow and safe query plumbing.

## Exec plan
- `.hermes/plans/2026-04-05-repo-index-search.md`
