### PR TITLE
fix: return 404 for invalid repository status streams

### DIFF
--- a/test/repository-status-route.test.ts
+++ b/test/repository-status-route.test.ts
@@ -82,6 +82,30 @@ beforeEach(() => {
 })
 
 describe("repository status SSE route", () => {
+  test("returns 404 immediately for suspicious repository probe routes", async () => {
+    const response = await GET(new Request("http://localhost/api/repo/admin/.env/status"), {
+      params: Promise.resolve({ owner: "admin", repo: ".env" }),
+    })
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get("Content-Type")).toStartWith("application/json")
+    expect(await response.json()).toEqual({ error: "Repository not found." })
+    expect(snapshotCallCount).toBe(0)
+  })
+
+  test("returns 404 when the initial snapshot lookup is missing", async () => {
+    snapshotSequence.push(null)
+
+    const response = await GET(new Request("http://localhost/api/repo/schema-labs-ltd/discofork/status"), {
+      params: Promise.resolve({ owner: "schema-labs-ltd", repo: "discofork" }),
+    })
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get("Content-Type")).toStartWith("application/json")
+    expect(await response.json()).toEqual({ error: "Repository not found." })
+    expect(snapshotCallCount).toBe(1)
+  })
+
   test("emits a first ready snapshot and closes cleanly", async () => {
     snapshotSequence.push(baseSnapshot("ready"))
 
@@ -93,6 +117,22 @@ describe("repository status SSE route", () => {
 
     const body = await readWithTimeout(response.text(), 1000, "the ready SSE body")
     expect(body).toContain('"fullName":"schema-labs-ltd/discofork"')
+    expect(body).toContain('"status":"ready"')
+    expect(snapshotCallCount).toBe(1)
+  })
+
+  test("preserves legitimate dotted repository names", async () => {
+    snapshotSequence.push(baseSnapshot("ready"))
+
+    const response = await GET(new Request("http://localhost/api/repo/github/.github/status"), {
+      params: Promise.resolve({ owner: "github", repo: ".github" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream")
+
+    const body = await readWithTimeout(response.text(), 1000, "the dotted repository SSE body")
+    expect(body).toContain('"fullName":"github/.github"')
     expect(body).toContain('"status":"ready"')
     expect(snapshotCallCount).toBe(1)
   })
@@ -129,7 +169,7 @@ describe("repository status SSE route", () => {
     expect(finalRead.done).toBeTrue()
   })
 
-  test("closes without emitting when the client aborts during the initial snapshot", async () => {
+  test("returns no content when the client aborts during the initial snapshot lookup", async () => {
     let resolveSnapshot: ((snapshot: Snapshot | null) => void) | null = null
     const delayedSnapshot = new Promise<Snapshot | null>((resolve) => {
       resolveSnapshot = resolve
@@ -137,7 +177,7 @@ describe("repository status SSE route", () => {
     snapshotSequence.push(delayedSnapshot)
 
     const abortController = new AbortController() as unknown as { signal: AbortSignal; abort: () => void }
-    const response = await GET(
+    const responsePromise = GET(
       new Request("http://localhost/api/repo/schema-labs-ltd/discofork/status", {
         signal: abortController.signal,
       }),
@@ -146,18 +186,18 @@ describe("repository status SSE route", () => {
       },
     )
 
-    const reader = response.body?.getReader()
-    expect(reader).toBeDefined()
-
+    await Bun.sleep(0)
     abortController.abort()
+
     if (!resolveSnapshot) {
       throw new Error("Expected the delayed snapshot resolver to be set")
     }
     const deliverSnapshot = resolveSnapshot as (snapshot: Snapshot | null) => void
     deliverSnapshot(baseSnapshot("queued"))
 
-    const finalRead = await readWithTimeout<StreamRead>(reader!.read(), 1000, "stream shutdown during the initial snapshot")
-    expect(finalRead.done).toBeTrue()
+    const response = await readWithTimeout<Response>(responsePromise, 1000, "the aborted initial lookup response")
+    expect(response.status).toBe(204)
+    expect(response.body).toBeNull()
     expect(snapshotCallCount).toBe(1)
   })
 })

--- a/web/src/app/api/repo/[owner]/[repo]/status/route.ts
+++ b/web/src/app/api/repo/[owner]/[repo]/status/route.ts
@@ -1,3 +1,4 @@
+import { describeSuspiciousRepositoryRoute } from "@/lib/repository-route-validation"
 import { getRepoStatusSnapshot } from "@/lib/server/live-status"
 
 type RouteProps = {
@@ -11,9 +12,72 @@ function sseFrame(data: unknown): Uint8Array {
   return new TextEncoder().encode(`data: ${JSON.stringify(data)}\n\n`)
 }
 
+function notFoundResponse() {
+  return Response.json({ error: "Repository not found." }, { status: 404 })
+}
+
+const ABORTED_DURING_INITIAL_LOOKUP = Symbol("aborted-during-initial-lookup")
+
+type InitialSnapshot = Awaited<ReturnType<typeof getRepoStatusSnapshot>>
+
+async function getInitialSnapshotOrAbort(
+  request: Request,
+  fullName: string,
+): Promise<InitialSnapshot | typeof ABORTED_DURING_INITIAL_LOOKUP> {
+  if (request.signal.aborted) {
+    return ABORTED_DURING_INITIAL_LOOKUP
+  }
+
+  return await new Promise<InitialSnapshot | typeof ABORTED_DURING_INITIAL_LOOKUP>((resolve, reject) => {
+    let settled = false
+
+    const finish = (
+      value: InitialSnapshot | typeof ABORTED_DURING_INITIAL_LOOKUP,
+      error?: unknown,
+    ) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      request.signal.removeEventListener("abort", handleAbort)
+
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve(value)
+    }
+
+    const handleAbort = () => {
+      finish(ABORTED_DURING_INITIAL_LOOKUP)
+    }
+
+    request.signal.addEventListener("abort", handleAbort, { once: true })
+
+    void getRepoStatusSnapshot(fullName).then(
+      (snapshot) => finish(snapshot),
+      (error) => finish(ABORTED_DURING_INITIAL_LOOKUP, error),
+    )
+  })
+}
+
 export async function GET(request: Request, { params }: RouteProps) {
   const { owner, repo } = await params
+  if (describeSuspiciousRepositoryRoute(owner, repo)) {
+    return notFoundResponse()
+  }
+
   const fullName = `${owner}/${repo}`
+  const initialSnapshot = await getInitialSnapshotOrAbort(request, fullName)
+  if (initialSnapshot === ABORTED_DURING_INITIAL_LOOKUP) {
+    return new Response(null, { status: 204 })
+  }
+
+  if (!initialSnapshot) {
+    return notFoundResponse()
+  }
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -40,9 +104,14 @@ export async function GET(request: Request, { params }: RouteProps) {
         controller.close()
       }
 
-      const sendSnapshot = async () => {
-        const snapshot = await getRepoStatusSnapshot(fullName)
+      const sendSnapshot = async (snapshotOverride?: NonNullable<typeof initialSnapshot>) => {
+        const snapshot = snapshotOverride ?? (await getRepoStatusSnapshot(fullName))
         if (closed) {
+          return
+        }
+
+        if (!snapshot) {
+          closeStream()
           return
         }
 
@@ -53,7 +122,7 @@ export async function GET(request: Request, { params }: RouteProps) {
           }),
         )
 
-        if (snapshot?.status === "ready") {
+        if (snapshot.status === "ready") {
           closeStream()
         }
       }
@@ -65,7 +134,7 @@ export async function GET(request: Request, { params }: RouteProps) {
         return
       }
 
-      await sendSnapshot()
+      await sendSnapshot(initialSnapshot)
 
       if (!closed) {
         interval = setInterval(() => {


### PR DESCRIPTION
Closes #49

## Summary
- reuse the shared repository-route validation helper in the status SSE route
- return 404 before opening SSE when the initial status snapshot is missing
- preserve legitimate dotted repositories and restore abort-aware initial lookup coverage

## Validation
- npx bun test test/repository-status-route.test.ts
- npx bun run typecheck
- (cd web && npx bun run typecheck)

## Review gate
- Reviewer-only fallback via `codex exec` because the full `review-changes` orchestration path was unavailable in this environment
- Final fallback review reported no findings

## Notes
- `npx bun test` still shows unrelated `test/repository-service-page-view.test.ts` interaction failures when run alongside other files, but that file passes in isolation and was outside this issue's scope.

