### PR TITLE
fix: render cached repository views without Redis

### DIFF
--- a/test/repository-service-page-view.test.ts
+++ b/test/repository-service-page-view.test.ts
@@ -27,6 +27,35 @@ let RepositoryNotFoundError: typeof Error
 let getRepositoryPageView: (owner: string, repo: string) => Promise<any>
 let readRepositoryView: (owner: string, repo: string) => Promise<any>
 
+function createRepoRecord(overrides: Record<string, unknown> = {}): any {
+  const owner = (overrides.owner as string | undefined) ?? "schema-labs-ltd"
+  const repo = (overrides.repo as string | undefined) ?? "discofork"
+  const fullName = (overrides.full_name as string | undefined) ?? `${owner}/${repo}`
+
+  return {
+    full_name: fullName,
+    owner,
+    repo,
+    github_url: (overrides.github_url as string | undefined) ?? `https://github.com/${fullName}`,
+    status: "queued",
+    report_json: null,
+    error_message: null,
+    last_requested_at: "2026-04-04T00:00:00Z",
+    queued_at: "2026-04-04T00:00:00Z",
+    processing_started_at: null,
+    cached_at: null,
+    retry_count: 0,
+    retry_state: "none",
+    next_retry_at: null,
+    last_failed_at: null,
+    last_error_message: null,
+    failure_history: [],
+    created_at: "2026-04-04T00:00:00Z",
+    updated_at: "2026-04-04T00:00:00Z",
+    ...overrides,
+  }
+}
+
 function applyRepositoryServiceMocks() {
   mock.module(databaseModulePath, () => ({
     databaseConfigured: () => databaseEnabled,
@@ -52,21 +81,11 @@ function applyRepositoryServiceMocks() {
     },
     touchQueuedRepo: async (owner: string, repo: string, queuedNow: boolean) => {
       touchCalls.push({ owner, repo, queuedNow })
-      repoRecord = {
-        full_name: `${owner}/${repo}`,
+      repoRecord = createRepoRecord({
         owner,
         repo,
-        github_url: `https://github.com/${owner}/${repo}`,
         status: "queued",
-        report_json: null,
-        error_message: null,
-        last_requested_at: "2026-04-04T00:00:00Z",
-        queued_at: "2026-04-04T00:00:00Z",
-        processing_started_at: null,
-        cached_at: null,
-        created_at: "2026-04-04T00:00:00Z",
-        updated_at: "2026-04-04T00:00:00Z",
-      }
+      })
       statusSnapshot = {
         status: "queued",
         queuePosition: 1,
@@ -130,6 +149,8 @@ describe("repository page view loading", () => {
 
     expect(firstView.kind).toBe("queued")
     expect(secondView.kind).toBe("queued")
+    expect(firstView.liveStatusEnabled).toBeTrue()
+    expect(secondView.liveStatusEnabled).toBeTrue()
     expect(enqueueCalls).toEqual(["schema-labs-ltd/discofork"])
     expect(touchCalls).toEqual([{ owner: "schema-labs-ltd", repo: "discofork", queuedNow: true }])
   })
@@ -141,6 +162,109 @@ describe("repository page view loading", () => {
     expect(enqueueCalls).toEqual([])
     expect(touchCalls).toEqual([])
     expect(fetchCalls).toEqual([])
+  })
+
+  test("readRepositoryView returns a stored ready report when Redis is unavailable", async () => {
+    queueEnabled = false
+    repoRecord = createRepoRecord({
+      status: "ready",
+      report_json: {
+        generatedAt: "2026-04-05T00:00:00Z",
+        upstream: {
+          metadata: {
+            stargazerCount: 7,
+            forkCount: 3,
+            defaultBranch: "main",
+            pushedAt: "2026-04-03T00:00:00Z",
+          },
+          analysis: {
+            summary: "Cached summary from Postgres",
+          },
+        },
+        recommendations: {
+          bestMaintained: "schema-labs-ltd/discofork",
+        },
+      },
+      cached_at: "2026-04-05T00:00:00Z",
+    })
+
+    const view = await readRepositoryView("schema-labs-ltd", "discofork")
+
+    expect(view.kind).toBe("cached")
+    expect(view.upstreamSummary).toBe("Cached summary from Postgres")
+    expect(view.recommendations.bestMaintained).toBe("schema-labs-ltd/discofork")
+    expect(repoRecordLookups).toEqual(["schema-labs-ltd/discofork"])
+    expect(enqueueCalls).toEqual([])
+    expect(touchCalls).toEqual([])
+    expect(fetchCalls).toEqual([])
+  })
+
+  for (const status of ["queued", "failed"] as const) {
+    test(`getRepositoryPageView returns a stored ${status} row without enqueueing when Redis is unavailable`, async () => {
+      queueEnabled = false
+      repoRecord = createRepoRecord({
+        status,
+        error_message: status === "failed" ? "Worker crashed" : null,
+        retry_count: status === "failed" ? 3 : 0,
+        retry_state: status === "failed" ? "terminal" : "none",
+        last_failed_at: status === "failed" ? "2026-04-04T01:00:00Z" : null,
+      })
+
+      const view = await getRepositoryPageView("schema-labs-ltd", "discofork")
+
+      expect(view.kind).toBe("queued")
+      expect(view.status).toBe(status)
+      expect(view.liveStatusEnabled).toBeFalse()
+      expect(view.errorMessage).toBe(status === "failed" ? "Worker crashed" : null)
+      expect(repoRecordLookups).toEqual(["schema-labs-ltd/discofork"])
+      expect(enqueueCalls).toEqual([])
+      expect(touchCalls).toEqual([])
+      expect(fetchCalls).toEqual([])
+    })
+  }
+
+  test("getRepositoryPageView keeps live status polling enabled for stored processing rows without Redis", async () => {
+    queueEnabled = false
+    repoRecord = createRepoRecord({
+      status: "processing",
+      processing_started_at: "2026-04-04T00:05:00Z",
+    })
+
+    const view = await getRepositoryPageView("schema-labs-ltd", "discofork")
+
+    expect(view.kind).toBe("queued")
+    expect(view.status).toBe("processing")
+    expect(view.liveStatusEnabled).toBeTrue()
+    expect(view.queueHint).toContain("currently being analyzed")
+    expect(enqueueCalls).toEqual([])
+    expect(touchCalls).toEqual([])
+  })
+
+  test("getRepositoryPageView stays non-mutating for uncached repos when Redis is unavailable", async () => {
+    queueEnabled = false
+
+    const view = await getRepositoryPageView("schema-labs-ltd", "uncached-without-redis")
+
+    expect(view.kind).toBe("queued")
+    expect(view.liveStatusEnabled).toBeFalse()
+    expect(view.queueHint).toContain("queueing is unavailable")
+    expect(repoRecordLookups).toEqual(["schema-labs-ltd/uncached-without-redis"])
+    expect(enqueueCalls).toEqual([])
+    expect(touchCalls).toEqual([])
+    expect(fetchCalls).toEqual([])
+  })
+
+  test("getRepositoryPageView still rejects missing repos without Redis when GitHub says they do not exist", async () => {
+    queueEnabled = false
+    process.env.GH_TOKEN = "***"
+    fetchStatus = 404
+
+    await expect(getRepositoryPageView("schema-labs-ltd", "missing-without-redis")).rejects.toBeInstanceOf(RepositoryNotFoundError)
+
+    expect(repoRecordLookups).toEqual(["schema-labs-ltd/missing-without-redis"])
+    expect(enqueueCalls).toEqual([])
+    expect(touchCalls).toEqual([])
+    expect(fetchCalls).toEqual(["https://api.github.com/repos/schema-labs-ltd/missing-without-redis"])
   })
 
   test("rejects suspicious page routes before stored lookups, fetches, or queue mutations", async () => {
@@ -156,21 +280,11 @@ describe("repository page view loading", () => {
 
   test("rejects suspicious read-only routes before stored lookup side effects", async () => {
     process.env.GH_TOKEN = "***"
-    repoRecord = {
-      full_name: ".well-known/nodeinfo",
+    repoRecord = createRepoRecord({
       owner: ".well-known",
       repo: "nodeinfo",
-      github_url: "https://github.com/.well-known/nodeinfo",
       status: "queued",
-      report_json: null,
-      error_message: null,
-      last_requested_at: "2026-04-04T00:00:00Z",
-      queued_at: "2026-04-04T00:00:00Z",
-      processing_started_at: null,
-      cached_at: null,
-      created_at: "2026-04-04T00:00:00Z",
-      updated_at: "2026-04-04T00:00:00Z",
-    }
+    })
 
     await expect(readRepositoryView(".well-known", "nodeinfo")).rejects.toBeInstanceOf(RepositoryNotFoundError)
 

--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -38,6 +38,14 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
   const [liveView, setLiveView] = useState(view)
 
   useEffect(() => {
+    setLiveView(view)
+  }, [view])
+
+  useEffect(() => {
+    if (!view.liveStatusEnabled) {
+      return
+    }
+
     const source = new EventSource(`/api/repo/${view.owner}/${view.repo}/status`)
 
     source.onmessage = (event) => {
@@ -85,7 +93,7 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
     return () => {
       source.close()
     }
-  }, [router, view.owner, view.repo])
+  }, [router, view.liveStatusEnabled, view.owner, view.repo])
 
   const progressPercent =
     liveView.progress?.current !== null &&
@@ -112,35 +120,41 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
           ? liveView.retryState === "terminal"
             ? "Terminal failure"
             : "Failed"
-          : "Queued lookup"
+          : !liveView.liveStatusEnabled
+            ? "No live status"
+            : "Queued lookup"
   const statusBadgeVariant =
     liveView.status === "processing" && liveView.retryState !== "retrying"
       ? "success"
       : liveView.status === "failed" || liveView.retryState === "retrying"
         ? "warning"
-        : "warning"
+        : !liveView.liveStatusEnabled
+          ? "muted"
+          : "warning"
 
   const liveHint =
-    liveView.retryState === "retrying"
-      ? liveView.nextRetryAt
-        ? `Discofork is retrying this repository after a transient failure. Retry ${liveView.retryCount} is scheduled for ${liveView.nextRetryAt}.`
-        : `Discofork is retrying this repository after a transient failure. Retry ${liveView.retryCount} is pending.`
-      : liveView.status === "processing"
-        ? "This repository is currently being analyzed by Discofork."
-        : liveView.status === "failed"
-          ? liveView.retryState === "terminal"
-            ? "The latest analysis exhausted the retry budget and now needs a manual requeue from the repository index."
-            : "The latest analysis failed. You can retry it from the repository index."
-          : typeof liveView.queuePosition === "number"
-            ? `This repository is queued for Discofork analysis. Current queue position: ${liveView.queuePosition}.`
-            : liveView.queueHint
+    !liveView.liveStatusEnabled
+      ? liveView.queueHint
+      : liveView.retryState === "retrying"
+        ? liveView.nextRetryAt
+          ? `Discofork is retrying this repository after a transient failure. Retry ${liveView.retryCount} is scheduled for ${liveView.nextRetryAt}.`
+          : `Discofork is retrying this repository after a transient failure. Retry ${liveView.retryCount} is pending.`
+        : liveView.status === "processing"
+          ? "This repository is currently being analyzed by Discofork."
+          : liveView.status === "failed"
+            ? liveView.retryState === "terminal"
+              ? "The latest analysis exhausted the retry budget and now needs a manual requeue from the repository index."
+              : "The latest analysis failed. You can retry it from the repository index."
+            : typeof liveView.queuePosition === "number"
+              ? `This repository is queued for Discofork analysis. Current queue position: ${liveView.queuePosition}.`
+              : liveView.queueHint
 
   return (
     <section className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_360px]">
       <div className="rounded-md border border-border bg-card p-6">
         <div className="flex flex-wrap items-center gap-3">
           <Badge variant={statusBadgeVariant}>{statusBadgeLabel}</Badge>
-          <Badge variant="muted">queued {liveView.queuedAt}</Badge>
+          {liveView.liveStatusEnabled ? <Badge variant="muted">queued {liveView.queuedAt}</Badge> : <Badge variant="muted">static fallback</Badge>}
           {typeof liveView.queuePosition === "number" ? <Badge variant="muted">queue #{liveView.queuePosition}</Badge> : null}
           {liveView.retryState === "retrying" ? <Badge variant="muted">retry {liveView.retryCount}</Badge> : null}
         </div>
@@ -154,7 +168,9 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
         <div className="mt-8 grid gap-4 md:grid-cols-3">
           <div className="rounded-md border border-border bg-muted/70 p-4">
             <Radar className="h-5 w-5 text-primary" />
-            <div className="mt-3 text-sm font-medium text-foreground">Lookup requested</div>
+            <div className="mt-3 text-sm font-medium text-foreground">
+              {liveView.liveStatusEnabled ? "Lookup requested" : "Live queue unavailable"}
+            </div>
           </div>
           <div className="rounded-md border border-border bg-muted/70 p-4">
             <Database className="h-5 w-5 text-primary" />
@@ -163,13 +179,15 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
           <div className="rounded-md border border-border bg-muted/70 p-4">
             <Clock3 className="h-5 w-5 text-primary" />
             <div className="mt-3 text-sm font-medium text-foreground">
-              {liveView.retryState === "retrying"
-                ? "Automatic retry scheduled"
-                : liveView.status === "processing"
-                  ? "Worker is running"
-                  : liveView.status === "failed"
-                    ? "Retry budget exhausted"
-                    : "Awaiting backend run"}
+              {!liveView.liveStatusEnabled
+                ? "No status row to stream yet"
+                : liveView.retryState === "retrying"
+                  ? "Automatic retry scheduled"
+                  : liveView.status === "processing"
+                    ? "Worker is running"
+                    : liveView.status === "failed"
+                      ? "Retry budget exhausted"
+                      : "Awaiting backend run"}
             </div>
           </div>
         </div>
@@ -180,15 +198,17 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
               <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Live status</div>
               <div className="mt-2 text-sm font-medium text-foreground">
                 {liveView.progress?.detail ??
-                  (liveView.retryState === "retrying"
-                    ? liveView.nextRetryAt
-                      ? `Waiting to retry at ${liveView.nextRetryAt}.`
-                      : `Retry ${liveView.retryCount} is pending.`
-                    : liveView.status === "processing"
-                      ? "Discofork is working through the analysis pipeline."
-                      : liveView.queuePosition
-                        ? `Waiting in queue at position ${liveView.queuePosition}.`
-                        : "Waiting for a worker to pick up this repository.")}
+                  (!liveView.liveStatusEnabled
+                    ? liveView.queueHint
+                    : liveView.retryState === "retrying"
+                      ? liveView.nextRetryAt
+                        ? `Waiting to retry at ${liveView.nextRetryAt}.`
+                        : `Retry ${liveView.retryCount} is pending.`
+                      : liveView.status === "processing"
+                        ? "Discofork is working through the analysis pipeline."
+                        : liveView.queuePosition
+                          ? `Waiting in queue at position ${liveView.queuePosition}.`
+                          : "Waiting for a worker to pick up this repository.")}
               </div>
             </div>
             {progressPercent !== null ? <div className="text-sm font-semibold text-foreground">{progressPercent}%</div> : null}
@@ -227,11 +247,23 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
 
         <div className="mt-8 space-y-3">
           <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">What happens next</div>
-          <ul className="space-y-3 text-sm leading-7 text-muted-foreground">
-            <li>The web backend has queued this repo in Redis if it was not already pending.</li>
-            <li>The Discofork worker will run the analysis pipeline and save the result in Postgres.</li>
-            <li>Transient worker failures now retry automatically with backoff before a terminal failure is surfaced.</li>
-          </ul>
+          {liveView.liveStatusEnabled ? (
+            <ul className="space-y-3 text-sm leading-7 text-muted-foreground">
+              <li>The web backend has queued this repo in Redis if it was not already pending.</li>
+              <li>The Discofork worker will run the analysis pipeline and save the result in Postgres.</li>
+              <li>Transient worker failures now retry automatically with backoff before a terminal failure is surfaced.</li>
+            </ul>
+          ) : (
+            <ul className="space-y-3 text-sm leading-7 text-muted-foreground">
+              <li>This view is a static fallback because Discofork cannot show Redis-backed live status updates right now.</li>
+              <li>{liveView.queueHint}</li>
+              <li>
+                {liveView.status === "failed"
+                  ? "Use the repository index to request another run after queueing is restored."
+                  : "Once queueing is restored, Discofork can resume live status updates for this repository from its stored state."}
+              </li>
+            </ul>
+          )}
         </div>
       </aside>
     </section>

--- a/web/src/lib/repository-service.ts
+++ b/web/src/lib/repository-service.ts
@@ -58,6 +58,7 @@ export type QueuedRepoView = {
   progress: RepoProgressSnapshot | null
   errorMessage: string | null
   queueHint: string
+  liveStatusEnabled: boolean
   retryCount: number
   retryState: "none" | "retrying" | "terminal"
   nextRetryAt: string | null
@@ -384,6 +385,11 @@ function queuedViewFromRecord(
 ): QueuedRepoView {
   const fullName = `${owner}/${repo}`
   const queuedStatus = toQueuedStatus(snapshot?.status ?? record.status)
+  const liveStatusEnabled = queueConfigured() || queuedStatus === "processing"
+  const retryState = snapshot?.retryState ?? record.retry_state
+  const queuePosition = snapshot?.queuePosition ?? null
+  const nextRetryAt = snapshot?.nextRetryAt ?? record.next_retry_at
+  const retryCount = snapshot?.retryCount ?? record.retry_count
 
   return {
     kind: "queued",
@@ -393,24 +399,27 @@ function queuedViewFromRecord(
     githubUrl: `https://github.com/${fullName}`,
     status: queuedStatus,
     queuedAt: toIsoString(snapshot?.queuedAt ?? record.queued_at) ?? new Date().toISOString(),
-    queuePosition: snapshot?.queuePosition ?? null,
+    queuePosition,
     progress: snapshot?.progress ?? null,
     errorMessage: snapshot?.errorMessage ?? record.error_message ?? null,
-    queueHint: queueHintForStatus(
-      queuedStatus,
-      snapshot?.retryState ?? record.retry_state,
-      snapshot?.queuePosition ?? null,
-      snapshot?.nextRetryAt ?? record.next_retry_at,
-      snapshot?.retryCount ?? record.retry_count,
-    ),
-    retryCount: snapshot?.retryCount ?? record.retry_count,
-    retryState: snapshot?.retryState ?? record.retry_state,
-    nextRetryAt: snapshot?.nextRetryAt ?? record.next_retry_at,
+    queueHint: liveStatusEnabled
+      ? queueHintForStatus(queuedStatus, retryState, queuePosition, nextRetryAt, retryCount)
+      : staticQueueHintForStatus(queuedStatus, retryState, nextRetryAt, retryCount),
+    liveStatusEnabled,
+    retryCount,
+    retryState,
+    nextRetryAt,
     lastFailedAt: snapshot?.lastFailedAt ?? record.last_failed_at,
   }
 }
 
-function fallbackQueuedView(owner: string, repo: string, queueHint: string): QueuedRepoView {
+const QUEUE_UNAVAILABLE_HINT = "No cached analysis was found. Redis queueing is unavailable, so this repository cannot be queued right now."
+
+type FallbackQueuedViewOptions = {
+  liveStatusEnabled?: boolean
+}
+
+function fallbackQueuedView(owner: string, repo: string, queueHint: string, options: FallbackQueuedViewOptions = {}): QueuedRepoView {
   const fullName = `${owner}/${repo}`
 
   return {
@@ -425,6 +434,7 @@ function fallbackQueuedView(owner: string, repo: string, queueHint: string): Que
     progress: null,
     errorMessage: null,
     queueHint,
+    liveStatusEnabled: options.liveStatusEnabled ?? false,
     retryCount: 0,
     retryState: "none",
     nextRetryAt: null,
@@ -452,13 +462,18 @@ export const readRepositoryView = cache(async (owner: string, repo: string): Pro
   assertRepositoryRouteIsAllowed(owner, repo)
   const fullName = `${owner}/${repo}`
 
-  if (databaseConfigured() && queueConfigured()) {
+  if (databaseConfigured()) {
     const storedView = await readStoredRepositoryView(owner, repo)
     if (storedView) {
       return storedView
     }
 
     await ensureGitHubRepositoryExists(fullName)
+
+    if (!queueConfigured()) {
+      return fallbackQueuedView(owner, repo, QUEUE_UNAVAILABLE_HINT)
+    }
+
     return fallbackQueuedView(owner, repo, "No cached data exists yet. Open the main repository page to queue this repository for Discofork analysis.")
   }
 
@@ -474,18 +489,23 @@ export const getRepositoryPageView = cache(async (owner: string, repo: string): 
   assertRepositoryRouteIsAllowed(owner, repo)
   const fullName = `${owner}/${repo}`
 
-  if (databaseConfigured() && queueConfigured()) {
+  if (databaseConfigured()) {
     const storedView = await readStoredRepositoryView(owner, repo)
     if (storedView) {
       return storedView
     }
 
     await ensureGitHubRepositoryExists(fullName)
+
+    if (!queueConfigured()) {
+      return fallbackQueuedView(owner, repo, QUEUE_UNAVAILABLE_HINT)
+    }
+
     const queuedNow = await enqueueRepoJob(fullName)
     await touchQueuedRepo(owner, repo, queuedNow)
 
     const refreshedView = await readStoredRepositoryView(owner, repo)
-    return refreshedView ?? fallbackQueuedView(owner, repo, "This repository has been queued for Discofork analysis.")
+    return refreshedView ?? fallbackQueuedView(owner, repo, "This repository has been queued for Discofork analysis.", { liveStatusEnabled: true })
   }
 
   return readRepositoryView(owner, repo)
@@ -514,6 +534,30 @@ function queueHintForStatus(
       return queuePosition ? `This repository is queued for Discofork analysis. Current queue position: ${queuePosition}.` : "This repository has been queued for Discofork analysis."
     default:
       return "No cached data exists yet. This repository has been queued for Discofork analysis."
+  }
+}
+
+function staticQueueHintForStatus(
+  status: QueuedRepoView["status"],
+  retryState: QueuedRepoView["retryState"],
+  nextRetryAt: string | null,
+  retryCount: number,
+): string {
+  switch (status) {
+    case "processing":
+      return "Discofork has a stored processing state for this repository, but Redis queueing is unavailable so live worker progress may be stale."
+    case "failed":
+      if (retryState === "retrying") {
+        return nextRetryAt
+          ? `Discofork recorded a pending retry for this repository, but Redis queueing is unavailable so retry ${retryCount} cannot be tracked live right now.`
+          : `Discofork recorded a pending retry for this repository, but Redis queueing is unavailable so retry ${retryCount} cannot be tracked live right now.`
+      }
+      return retryState === "terminal"
+        ? "The latest analysis exhausted the retry budget. Redis queueing is unavailable, so a new run cannot be requested right now."
+        : "The latest analysis failed. Redis queueing is unavailable, so a new run cannot be requested right now."
+    case "queued":
+    default:
+      return "Discofork has a stored queued state for this repository, but Redis queueing is unavailable so live queue progress is unavailable right now."
   }
 }
 

--- a/web/src/lib/repository-social.ts
+++ b/web/src/lib/repository-social.ts
@@ -60,7 +60,15 @@ function cachedDescription(view: CachedRepoView): string {
   return clip([base, suffix].filter(Boolean).join(" • "), 260)
 }
 
+function queueHintIndicatesUnavailable(queueHint: string): boolean {
+  return queueHint.includes("queueing is unavailable") || queueHint.includes("cannot be queued right now")
+}
+
 function queuedDescription(view: QueuedRepoView): string {
+  if (!view.liveStatusEnabled) {
+    return clip(`${view.fullName}: ${view.queueHint}`, 260)
+  }
+
   if (view.status === "processing") {
     return clip(`Discofork is currently processing ${view.fullName}. ${view.progress?.detail ?? "The analysis pipeline is running now."}`, 260)
   }
@@ -87,26 +95,55 @@ export function buildRepoSocialSummary(view: RepoView): RepoSocialSummary {
     }
   }
 
+  const queueUnavailable = queueHintIndicatesUnavailable(view.queueHint)
+
   return {
     title: `${view.fullName} · Discofork`,
     description: queuedDescription(view),
     imageTitle: view.fullName,
     imageSubtitle:
-      view.status === "processing"
-        ? clip(view.progress?.detail ?? "Discofork is actively processing this repository.", 180)
-        : view.status === "failed"
-          ? clip(view.errorMessage ?? "The latest Discofork run failed and needs a retry.", 180)
-          : clip(view.queueHint, 180),
-    statsLine:
-      view.status === "queued" && typeof view.queuePosition === "number"
-        ? `Queued for analysis • position #${view.queuePosition}`
+      !view.liveStatusEnabled
+        ? clip(view.queueHint, 180)
         : view.status === "processing"
-          ? "Analysis in progress"
-          : "Analysis needs a retry",
+          ? clip(view.progress?.detail ?? "Discofork is actively processing this repository.", 180)
+          : view.status === "failed"
+            ? clip(view.errorMessage ?? "The latest Discofork run failed and needs a retry.", 180)
+            : clip(view.queueHint, 180),
+    statsLine:
+      view.status === "processing"
+        ? "Analysis in progress"
+        : view.status === "failed"
+          ? "Analysis needs a retry"
+          : !view.liveStatusEnabled
+            ? queueUnavailable
+              ? "Live queueing unavailable"
+              : "Open page to queue analysis"
+            : view.status === "queued" && typeof view.queuePosition === "number"
+              ? `Queued for analysis • position #${view.queuePosition}`
+              : "Queued for analysis",
     forkHighlights:
       view.status === "processing"
-        ? ["Live worker progress is available on the Discofork page.", "This preview updates when the cached brief is ready."]
-        : ["Discofork will surface the strongest forks after the backend run completes.", "Open the page to watch queue position and live progress."],
+        ? [
+            view.liveStatusEnabled
+              ? "Live worker progress is available on the Discofork page."
+              : "This preview is showing a stored processing state without live Redis-backed progress.",
+            "This preview updates when the cached brief is ready.",
+          ]
+        : view.status === "failed"
+          ? [
+              view.queueHint,
+              queueUnavailable
+                ? "Use the repository index to request another run after Redis is restored."
+                : "Open the repository page or repository index to request another run.",
+            ]
+          : !view.liveStatusEnabled
+            ? [
+                queueUnavailable
+                  ? "This preview is showing a static fallback because live queueing is unavailable."
+                  : "This preview is showing a read-only fallback before the repository has been queued.",
+                view.queueHint,
+              ]
+            : ["Discofork will surface the strongest forks after the backend run completes.", "Open the page to watch queue position and live progress."],
   }
 }
 

--- a/web/src/lib/server/live-status.ts
+++ b/web/src/lib/server/live-status.ts
@@ -52,6 +52,18 @@ async function getRedisProgress(fullName: string): Promise<ProgressPayload | nul
   }
 }
 
+async function getSafeQueueState(fullName: string): Promise<{ queuePosition: number | null; processing: boolean }> {
+  if (!queueConfigured()) {
+    return { queuePosition: null, processing: false }
+  }
+
+  try {
+    return await getRepoQueueState(fullName)
+  } catch {
+    return { queuePosition: null, processing: false }
+  }
+}
+
 export async function getRepoStatusSnapshot(fullName: string): Promise<RepoStatusSnapshot | null> {
   const rows = await query<{
     status: "queued" | "processing" | "ready" | "failed"
@@ -84,10 +96,7 @@ export async function getRepoStatusSnapshot(fullName: string): Promise<RepoStatu
     return null
   }
 
-  const [queueState, liveProgress] = await Promise.all([
-    queueConfigured() ? getRepoQueueState(fullName) : Promise.resolve({ queuePosition: null, processing: false }),
-    getRedisProgress(fullName),
-  ])
+  const [queueState, liveProgress] = await Promise.all([getSafeQueueState(fullName), getRedisProgress(fullName)])
 
   const status =
     row.status === "ready"


### PR DESCRIPTION
## Summary
- render stored Postgres-backed repository views even when Redis queueing is unavailable
- avoid false live-queue copy for static fallback states while still polling stored processing rows
- harden live status snapshots against Redis queue-state lookup failures and add regression coverage

## Why
Cached repository briefs and stored queued/failed states should still be visible during Redis outages or partial rollouts. This keeps repository pages and API responses useful instead of hiding valid stored data behind misleading queue fallbacks.

## Validation
- npx bun test test/repository-service-page-view.test.ts
- npx bun test test/repo-api-route.test.ts
- npx bun run typecheck
- cd web && npx bun run typecheck

## Notes
- Exec plan path: .hermes/plans/2026-04-11-render-cached-reports-without-redis.md
- Review gate used reviewer-only fallback because the normal review-changes orchestration path was degraded in this run; blocking findings from that review were fixed before delivery.

Closes #51