### PR TITLE
Fix #53: correct admin failed requeue query construction

### DIFF
--- a/test/admin-requeue-failed.test.ts
+++ b/test/admin-requeue-failed.test.ts
@@ -21,7 +21,7 @@ function runBunScript<T>(script: string): ScriptResult<T> {
 }
 
 describe("failed repo bulk requeue", () => {
-  test("listFailedRepoNames excludes suspicious routes from the failed-row query", () => {
+  test("listFailedRepoNames builds a real failed-row WHERE clause and preserves suspicious-route filtering", () => {
     const result = runBunScript<{ names: string[]; queryCalls: Array<{ sql: string; params: unknown[] }> }>(`
       import { mock } from "bun:test"
       const databaseModulePath = new URL("./web/src/lib/server/database.ts", import.meta.url).href
@@ -42,9 +42,10 @@ describe("failed repo bulk requeue", () => {
     expect(result.stderr).toBe("")
     expect(result.stdout.names).toEqual(["schema-labs-ltd/discofork"])
     expect(result.stdout.queryCalls).toHaveLength(1)
-    expect(result.stdout.queryCalls[0]?.params).toEqual([])
+    expect(result.stdout.queryCalls[0]?.params).toEqual(["failed"])
+    expect(result.stdout.queryCalls[0]?.sql).not.toContain("[object Object]")
     expect(result.stdout.queryCalls[0]?.sql).toContain("where not (")
-    expect(result.stdout.queryCalls[0]?.sql).toContain("status = 'failed'")
+    expect(result.stdout.queryCalls[0]?.sql).toContain("status = $1")
     expect(result.stdout.queryCalls[0]?.sql).toContain("lower(owner) in ('.well-known')")
     expect(result.stdout.queryCalls[0]?.sql).toContain("lower(owner || '/' || repo) in ('admin/.env', 'wp-admin/admin-ajax.php')")
   })

--- a/web/src/lib/server/reports.ts
+++ b/web/src/lib/server/reports.ts
@@ -236,11 +236,13 @@ export async function listRepoRecords(
 }
 
 export async function listFailedRepoNames(): Promise<string[]> {
+  const failedWhereClause = buildRepoListWhereClause("failed")
   const rows = await query<{ full_name: string }>(
     `select full_name
     from repo_reports
-    ${buildRepoListWhereClause("failed")}
+    ${failedWhereClause.clause}
     order by updated_at desc, full_name asc`,
+    failedWhereClause.params,
   )
 
   return rows.map((row) => row.full_name)


### PR DESCRIPTION
Closes #53

## Why

The admin bulk failed-requeue flow was interpolating the repo-list where-clause helper incorrectly, which degraded the SQL into `[object Object]` and could drop the intended failed-row filtering.

## What changed

- wire `listFailedRepoNames()` to the shared `buildRepoListWhereClause("failed")` result correctly
- pass the generated clause and params into the failed-row query so the suspicious-route exclusion and failed-status filter stay intact
- update the focused admin requeue regression to lock the SQL shape and queued-success behavior

## Impact

Admin bulk failed requeue now fetches only legitimate failed repositories with a real `WHERE` clause and continues to report accurate failed/requeued counts.

## Testing

- `npx bun test test/admin-requeue-failed.test.ts`
- `npx bun test test/repository-list-filter.test.ts`
- `npx bun run typecheck`
- `(cd web && npx bun run typecheck)`
- reviewer-only fallback `codex review --uncommitted`

## Out of scope / follow-ups

- No broader admin workflow changes; this stays tightly scoped to the failed-row query wiring and its focused regression coverage.

