### PR TITLE
fix: atomically enqueue repo jobs

### DIFF
--- a/src/server/queue.ts
+++ b/src/server/queue.ts
@@ -34,6 +34,20 @@ export function queueDedupeKey(fullName: string): string {
   return `${REPO_QUEUE_DEDUPE_PREFIX}${fullName}`
 }
 
+const ATOMIC_ENQUEUE_REPO_JOB_SCRIPT = `
+local dedupeKey = KEYS[1]
+local queueKey = KEYS[2]
+local fullName = ARGV[1]
+local ttlSeconds = ARGV[2]
+
+if redis.call("SET", dedupeKey, "1", "NX", "EX", ttlSeconds) then
+  redis.call("LPUSH", queueKey, fullName)
+  return 1
+end
+
+return 0
+`
+
 async function repoJobAlreadyTracked(redis: RedisClientType, fullName: string): Promise<boolean> {
   const [queuedIndex, processingIndex] = await Promise.all([
     redis.sendCommand<number | null>(["LPOS", REPO_QUEUE_KEY, fullName]),
@@ -49,26 +63,29 @@ async function restoreQueueDedupe(redis: RedisClientType, fullName: string): Pro
   })
 }
 
+async function enqueueRepoJobAtomically(redis: RedisClientType, fullName: string): Promise<boolean> {
+  const result = await redis.sendCommand<number | string>([
+    "EVAL",
+    ATOMIC_ENQUEUE_REPO_JOB_SCRIPT,
+    "2",
+    queueDedupeKey(fullName),
+    REPO_QUEUE_KEY,
+    fullName,
+    String(REPO_QUEUE_DEDUPE_TTL_SECONDS),
+  ])
+
+  return Number(result) === 1
+}
+
 export async function enqueueRepoJob(fullName: string): Promise<boolean> {
   const redis = await getRedisClient()
-  const key = queueDedupeKey(fullName)
 
   if (await repoJobAlreadyTracked(redis, fullName)) {
     await restoreQueueDedupe(redis, fullName)
     return false
   }
 
-  const wasQueued = await redis.set(key, "1", {
-    NX: true,
-    EX: REPO_QUEUE_DEDUPE_TTL_SECONDS,
-  })
-
-  if (!wasQueued) {
-    return false
-  }
-
-  await redis.lPush(REPO_QUEUE_KEY, fullName)
-  return true
+  return enqueueRepoJobAtomically(redis, fullName)
 }
 
 export async function dequeueRepoJob(timeoutSeconds: number): Promise<string | null> {

--- a/test/queue-dedupe.test.ts
+++ b/test/queue-dedupe.test.ts
@@ -17,6 +17,12 @@ const kvStore = new Map<string, string>()
 const listStore = new Map<string, string[]>()
 const setCalls: Array<{ key: string; value: string; options?: SetOptions }> = []
 const lPushCalls: Array<{ key: string; value: string }> = []
+const evalCalls: Array<{
+  script: string
+  keyCount: string
+  keys: string[]
+  args: string[]
+}> = []
 const connectCalls: string[] = []
 const createdTempDirs: string[] = []
 
@@ -45,18 +51,47 @@ const fakeRedis = {
     return items.length
   },
   sendCommand: async <T>(args: string[]): Promise<T> => {
-    const command = args[0]
-    const key = args[1]
-    const value = args[2]
+    const [command, ...rest] = args
 
-    if (!command || !key || !value) {
+    if (!command) {
       throw new Error(`Malformed Redis command: ${args.join(" ")}`)
     }
 
     if (command === "LPOS") {
+      const [key, value] = rest
+
+      if (!key || !value) {
+        throw new Error(`Malformed Redis command: ${args.join(" ")}`)
+      }
+
       const items = listStore.get(key) ?? []
       const index = items.indexOf(value)
       return (index === -1 ? null : index) as T
+    }
+
+    if (command === "EVAL") {
+      const [script, keyCount, dedupeKey, queueKey, fullName, ttlSeconds] = rest
+
+      if (!script || !keyCount || !dedupeKey || !queueKey || !fullName || !ttlSeconds) {
+        throw new Error(`Malformed Redis command: ${args.join(" ")}`)
+      }
+
+      evalCalls.push({
+        script,
+        keyCount,
+        keys: [dedupeKey, queueKey],
+        args: [fullName, ttlSeconds],
+      })
+
+      if (kvStore.has(dedupeKey)) {
+        return 0 as T
+      }
+
+      kvStore.set(dedupeKey, "1")
+      const items = listStore.get(queueKey) ?? []
+      items.unshift(fullName)
+      listStore.set(queueKey, items)
+      return 1 as T
     }
 
     throw new Error(`Unexpected Redis command: ${args.join(" ")}`)
@@ -74,6 +109,7 @@ beforeEach(() => {
   listStore.clear()
   setCalls.length = 0
   lPushCalls.length = 0
+  evalCalls.length = 0
   connectCalls.length = 0
 })
 
@@ -122,7 +158,7 @@ function dedupeKey(fullName: string): string {
 
 for (const target of targets) {
   describe(target.label, () => {
-    test("queues a brand-new repo once with NX dedupe", async () => {
+    test("queues a brand-new repo atomically with the dedupe key", async () => {
       const { enqueueRepoJob } = await import(buildModuleUrl(target)) as {
         enqueueRepoJob: (fullName: string) => Promise<boolean>
       }
@@ -132,18 +168,35 @@ for (const target of targets) {
 
       expect(queued).toBe(true)
       expect(connectCalls).toEqual(["connect"])
-      expect(setCalls).toEqual([
-        {
-          key: dedupeKey(fullName),
-          value: "1",
-          options: {
-            NX: true,
-            EX: REPO_QUEUE_DEDUPE_TTL_SECONDS,
-          },
-        },
-      ])
-      expect(lPushCalls).toEqual([{ key: REPO_QUEUE_KEY, value: fullName }])
+      expect(setCalls).toEqual([])
+      expect(lPushCalls).toEqual([])
+      expect(evalCalls).toHaveLength(1)
+      expect(evalCalls[0]).toMatchObject({
+        keyCount: "2",
+        keys: [dedupeKey(fullName), REPO_QUEUE_KEY],
+        args: [fullName, String(REPO_QUEUE_DEDUPE_TTL_SECONDS)],
+      })
+      expect(evalCalls[0]?.script).toContain('redis.call("SET", dedupeKey, "1", "NX", "EX", ttlSeconds)')
+      expect(evalCalls[0]?.script).toContain('redis.call("LPUSH", queueKey, fullName)')
+      expect(kvStore.get(dedupeKey(fullName))).toBe("1")
       expect(listStore.get(REPO_QUEUE_KEY)).toEqual([fullName])
+    })
+
+    test("does not enqueue again when the dedupe key already exists", async () => {
+      const { enqueueRepoJob } = await import(buildModuleUrl(target)) as {
+        enqueueRepoJob: (fullName: string) => Promise<boolean>
+      }
+      const fullName = "schema-labs-ltd/discofork"
+      kvStore.set(dedupeKey(fullName), "1")
+
+      const queued = await enqueueRepoJob(fullName)
+
+      expect(queued).toBe(false)
+      expect(setCalls).toEqual([])
+      expect(lPushCalls).toEqual([])
+      expect(evalCalls).toHaveLength(1)
+      expect(listStore.get(REPO_QUEUE_KEY)).toBeUndefined()
+      expect(kvStore.get(dedupeKey(fullName))).toBe("1")
     })
 
     test("treats a queued repo as already tracked even when the dedupe key expired", async () => {
@@ -157,6 +210,7 @@ for (const target of targets) {
 
       expect(queued).toBe(false)
       expect(lPushCalls).toEqual([])
+      expect(evalCalls).toEqual([])
       expect(listStore.get(REPO_QUEUE_KEY)).toEqual([fullName])
       expect(kvStore.get(dedupeKey(fullName))).toBe("1")
       expect(setCalls).toEqual([
@@ -181,6 +235,7 @@ for (const target of targets) {
 
       expect(queued).toBe(false)
       expect(lPushCalls).toEqual([])
+      expect(evalCalls).toEqual([])
       expect(listStore.get(REPO_PROCESSING_QUEUE_KEY)).toEqual([fullName])
       expect(kvStore.get(dedupeKey(fullName))).toBe("1")
       expect(setCalls).toEqual([
@@ -208,21 +263,19 @@ for (const target of targets) {
       kvStore.delete(dedupeKey(fullName))
       setCalls.length = 0
       lPushCalls.length = 0
+      evalCalls.length = 0
 
       const secondAttempt = await enqueueRepoJob(fullName)
 
       expect(secondAttempt).toBe(true)
-      expect(setCalls).toEqual([
-        {
-          key: dedupeKey(fullName),
-          value: "1",
-          options: {
-            NX: true,
-            EX: REPO_QUEUE_DEDUPE_TTL_SECONDS,
-          },
-        },
-      ])
-      expect(lPushCalls).toEqual([{ key: REPO_QUEUE_KEY, value: fullName }])
+      expect(setCalls).toEqual([])
+      expect(lPushCalls).toEqual([])
+      expect(evalCalls).toHaveLength(1)
+      expect(evalCalls[0]).toMatchObject({
+        keyCount: "2",
+        keys: [dedupeKey(fullName), REPO_QUEUE_KEY],
+        args: [fullName, String(REPO_QUEUE_DEDUPE_TTL_SECONDS)],
+      })
       expect(listStore.get(REPO_QUEUE_KEY)).toEqual([fullName])
     })
   })

--- a/web/src/lib/server/queue.ts
+++ b/web/src/lib/server/queue.ts
@@ -33,6 +33,20 @@ function queueDedupeKey(fullName: string): string {
   return `${REPO_QUEUE_DEDUPE_PREFIX}${fullName}`
 }
 
+const ATOMIC_ENQUEUE_REPO_JOB_SCRIPT = `
+local dedupeKey = KEYS[1]
+local queueKey = KEYS[2]
+local fullName = ARGV[1]
+local ttlSeconds = ARGV[2]
+
+if redis.call("SET", dedupeKey, "1", "NX", "EX", ttlSeconds) then
+  redis.call("LPUSH", queueKey, fullName)
+  return 1
+end
+
+return 0
+`
+
 async function repoJobAlreadyTracked(redis: RedisClientType, fullName: string): Promise<boolean> {
   const [queuedIndex, processingIndex] = await Promise.all([
     redis.sendCommand<number | null>(["LPOS", REPO_QUEUE_KEY, fullName]),
@@ -48,6 +62,20 @@ async function restoreQueueDedupe(redis: RedisClientType, fullName: string): Pro
   })
 }
 
+async function enqueueRepoJobAtomically(redis: RedisClientType, fullName: string): Promise<boolean> {
+  const result = await redis.sendCommand<number | string>([
+    "EVAL",
+    ATOMIC_ENQUEUE_REPO_JOB_SCRIPT,
+    "2",
+    queueDedupeKey(fullName),
+    REPO_QUEUE_KEY,
+    fullName,
+    String(REPO_QUEUE_DEDUPE_TTL_SECONDS),
+  ])
+
+  return Number(result) === 1
+}
+
 export async function enqueueRepoJob(fullName: string): Promise<boolean> {
   const redis = await getRedisClient()
 
@@ -56,17 +84,7 @@ export async function enqueueRepoJob(fullName: string): Promise<boolean> {
     return false
   }
 
-  const queued = await redis.set(queueDedupeKey(fullName), "1", {
-    NX: true,
-    EX: REPO_QUEUE_DEDUPE_TTL_SECONDS,
-  })
-
-  if (!queued) {
-    return false
-  }
-
-  await redis.lPush(REPO_QUEUE_KEY, fullName)
-  return true
+  return enqueueRepoJobAtomically(redis, fullName)
 }
 
 export async function getRepoQueueState(fullName: string): Promise<{


### PR DESCRIPTION
Closes #55

## Summary
- make the new repo enqueue path atomic in both queue helpers with a Redis `EVAL` helper
- preserve the existing tracked-job LPOS checks and dedupe TTL refresh behavior
- extend the shared queue dedupe tests to assert the atomic path for both modules

## Validation
- `npx bun test test/queue-dedupe.test.ts`
- `npx bun run typecheck`
- `cd web && npx bun run typecheck`

## Review
- `review-changes` parallel orchestration was unavailable in this environment, so I used the documented reviewer-only fallback against the canonical local diff before committing.

## Notes
- Root and web `npx bun install` were required in this worktree to run the final typechecks; generated lockfile changes were reverted to keep this PR scoped to the reliability fix.
- Commit: `93c4542`
