### PR TITLE
Implement #59: Repository watch, fork filtering, and quick queue input

### DIFF
--- a/web/src/app/[owner]/[repo]/page.tsx
+++ b/web/src/app/[owner]/[repo]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 
 import { CachedRepositoryBrief, QueuedRepositoryBrief } from "@/components/repository-brief"
 import { RepoShell } from "@/components/repo-shell"
+import { WatchTouch } from "@/components/watch-touch"
 import { RepositoryNotFoundError, getRepositoryPageView, readRepositoryView } from "@/lib/repository-service"
 import { buildRepoSocialSummary, getSiteOrigin } from "@/lib/repository-social"
 
@@ -87,6 +88,7 @@ export default async function RepositoryPage({ params }: RepoPageProps) {
       compact
     >
       {view.kind === "cached" ? <CachedRepositoryBrief view={view} /> : <QueuedRepositoryBrief view={view} />}
+      <WatchTouch fullName={`${owner}/${repo}`} />
     </RepoShell>
   )
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { ArrowRight, Terminal } from "lucide-react"
 
+import { QueueInput } from "@/components/queue-input"
 import { RepoShell } from "@/components/repo-shell"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
@@ -46,6 +47,16 @@ export default function HomePage() {
                   <ArrowRight className="h-4 w-4" />
                 </Link>
               </div>
+            </div>
+          </div>
+
+          <div className="rounded-[1.25rem] border border-border bg-card/70 p-7 shadow-[0_24px_80px_rgba(0,0,0,0.28)]">
+            <div className="space-y-4">
+              <Badge variant="success">Queue a repository</Badge>
+              <p className="text-sm leading-7 text-muted-foreground">
+                Enter a GitHub repository to queue it for Discofork analysis. If cached data already exists, you will be taken straight to the brief.
+              </p>
+              <QueueInput placeholder="e.g., openai/codex" />
             </div>
           </div>
 

--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { ArrowRight, Database, GitFork, Search, Star } from "lucide-react"
 
 import { CompareBar } from "@/components/compare-toggle"
+import { QueueInput } from "@/components/queue-input"
 import { RepoRowActions } from "@/components/repo-row-actions"
 import { RepoOrderSelect } from "@/components/repo-order-select"
 import { RepoStatusFilter } from "@/components/repo-status-filter"
@@ -259,14 +260,22 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
             `DATABASE_URL` is not configured for the web backend yet, so the repository index is unavailable.
           </div>
         ) : view.items.length === 0 ? (
-          <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
-            {view.query ? (
-              <>
-                No repositories match <span className="font-medium text-foreground">“{view.query}”</span>. Try a broader owner or repo name, or clear the search.
-              </>
-            ) : (
-              "No repositories have been indexed yet."
-            )}
+          <div className="rounded-md border border-border bg-card p-6 space-y-4">
+            <p className="text-sm leading-7 text-muted-foreground">
+              {view.query ? (
+                <>
+                  No repositories match <span className="font-medium text-foreground">"{view.query}"</span>. Try a broader owner or repo name, or clear the search.
+                </>
+              ) : (
+                "No repositories have been indexed yet."
+              )}
+            </p>
+            {view.queueEnabled ? (
+              <div className="space-y-2">
+                <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Queue a repository</div>
+                <QueueInput placeholder="owner/repo to analyze" />
+              </div>
+            ) : null}
           </div>
         ) : (
           <div className="overflow-hidden rounded-md border border-border bg-card">

--- a/web/src/app/watched/page.tsx
+++ b/web/src/app/watched/page.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowRight, Eye, Trash2 } from "lucide-react"
+
+import { RepoShell } from "@/components/repo-shell"
+import { Badge } from "@/components/ui/badge"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { type WatchEntry, getWatches, removeWatch } from "@/lib/watches"
+
+export default function WatchedPage() {
+  const [watches, setWatches] = useState<WatchEntry[]>([])
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    setWatches(getWatches())
+  }, [])
+
+  const handleRemove = (fullName: string) => {
+    removeWatch(fullName)
+    setWatches(getWatches())
+  }
+
+  return (
+    <RepoShell
+      eyebrow="Watched"
+      title="Repositories you are watching."
+      description="Repositories you are watching for updates. When cached data changes after your last visit, a badge will indicate new activity. Watches are stored locally in your browser."
+      compact
+    >
+      <section className="space-y-6">
+        {!mounted ? (
+          <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+            Loading watched repositories...
+          </div>
+        ) : watches.length === 0 ? (
+          <div className="rounded-md border border-border bg-card p-6">
+            <div className="flex items-start gap-4">
+              <Eye className="mt-1 h-5 w-5 text-muted-foreground" />
+              <div className="space-y-3">
+                <h2 className="text-base font-semibold text-foreground">No watched repositories yet</h2>
+                <p className="text-sm leading-7 text-muted-foreground">
+                  Visit any repository page and click the Watch button to start tracking it for updates.
+                </p>
+                <Link
+                  href="/repos"
+                  className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}
+                >
+                  Browse repositories
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-border bg-card">
+            {watches.map((watch) => (
+              <div
+                key={watch.fullName}
+                className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
+              >
+                <div className="min-w-0 flex-1 space-y-1">
+                  <Link
+                    href={`/${watch.owner}/${watch.repo}`}
+                    className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                  >
+                    {watch.fullName}
+                  </Link>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>Watching since {new Date(watch.watchedAt).toLocaleDateString()}</span>
+                    <span>·</span>
+                    <span>Last visited {new Date(watch.lastVisitedAt).toLocaleDateString()}</span>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Link
+                    href={`/${watch.owner}/${watch.repo}`}
+                    className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
+                  >
+                    Open
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(watch.fullName)}
+                    className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
+                    aria-label={`Stop watching ${watch.fullName}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </RepoShell>
+  )
+}

--- a/web/src/components/queue-input.tsx
+++ b/web/src/components/queue-input.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { useRouter } from "next/navigation"
+import { ArrowRight, Search } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export function QueueInput({ placeholder = "owner/repo" }: { placeholder?: string }) {
+  const router = useRouter()
+  const [input, setInput] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      setError("")
+
+      const trimmed = input.trim()
+      if (!trimmed) {
+        setError("Please enter a repository name.")
+        return
+      }
+
+      const parts = trimmed.replace(/^https?:\/\/github\.com\//, "").split("/")
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        setError("Use the format owner/repo (e.g., openai/codex).")
+        return
+      }
+
+      const owner = parts[0]
+      const repo = parts[1].replace(/\.git$/, "")
+      setInput("")
+      router.push(`/${owner}/${repo}`)
+    },
+    [input, router],
+  )
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value)
+              setError("")
+            }}
+            placeholder={placeholder}
+            className="w-full rounded-md border border-border bg-background px-3 py-2 pl-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+          />
+        </div>
+        <Button type="submit" variant="default" className="gap-2 rounded-md px-4">
+          Queue
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+      {error ? <p className="text-xs text-rose-500">{error}</p> : null}
+    </form>
+  )
+}

--- a/web/src/components/repo-shell.tsx
+++ b/web/src/components/repo-shell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 import Link from "next/link"
-import { ArrowUpRight, Bookmark } from "lucide-react"
+import { ArrowUpRight, Bookmark, Eye } from "lucide-react"
 
 import { ThemeToggle } from "@/components/theme-toggle"
 import { buttonVariants } from "@/components/ui/button"
@@ -34,6 +34,10 @@ export function RepoShell({
             <Link href="/bookmarks" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")}>
               <Bookmark className="h-4 w-4" />
               Bookmarks
+            </Link>
+            <Link href="/watched" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")}>
+              <Eye className="h-4 w-4" />
+              Watched
             </Link>
             <Link href="/compare" className={cn(buttonVariants({ variant: "ghost" }), "text-muted-foreground")}>
               Compare

--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -1,12 +1,13 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { ArrowUpRight, Clock3, Database, Download, GitFork, Radar, Star } from "lucide-react"
+import { useRouter, useSearchParams, usePathname } from "next/navigation"
+import { ArrowUpRight, ArrowUpDown, Clock3, Database, Download, Filter, GitFork, Radar, Star, X } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { BookmarkButton } from "@/components/bookmark-button"
+import { WatchButton } from "@/components/watch-button"
 import { buttonVariants } from "@/components/ui/button"
 import type { CachedRepoView, QueuedRepoView } from "@/lib/repository-service"
 import { exportRepoBrief } from "@/lib/export-brief"
@@ -273,8 +274,65 @@ export function QueuedRepositoryBrief({ view }: { view: QueuedRepoView }) {
 }
 
 export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
-  const [selectedForkName, setSelectedForkName] = useState(view.forks[0]?.fullName ?? "")
-  const selectedFork = view.forks.find((fork) => fork.fullName === selectedForkName) ?? view.forks[0]
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const maintenanceFilter = searchParams.get("maintenance") ?? ""
+  const magnitudeFilter = searchParams.get("magnitude") ?? ""
+  const sortBy = searchParams.get("sort") ?? ""
+
+  const allMaintenances = useMemo(
+    () => [...new Set(view.forks.map((f) => f.maintenance))].sort(),
+    [view.forks],
+  )
+  const allMagnitudes = useMemo(
+    () => [...new Set(view.forks.map((f) => f.changeMagnitude))].sort(),
+    [view.forks],
+  )
+
+  const filteredForks = useMemo(() => {
+    let result = view.forks
+
+    if (maintenanceFilter) {
+      result = result.filter((f) => f.maintenance === maintenanceFilter)
+    }
+    if (magnitudeFilter) {
+      result = result.filter((f) => f.changeMagnitude === magnitudeFilter)
+    }
+    if (sortBy === "maintenance") {
+      result = [...result].sort((a, b) => a.maintenance.localeCompare(b.maintenance))
+    } else if (sortBy === "magnitude") {
+      result = [...result].sort((a, b) => a.changeMagnitude.localeCompare(b.changeMagnitude))
+    } else if (sortBy === "name") {
+      result = [...result].sort((a, b) => a.fullName.localeCompare(b.fullName))
+    }
+
+    return result
+  }, [view.forks, maintenanceFilter, magnitudeFilter, sortBy])
+
+  const [selectedForkName, setSelectedForkName] = useState(filteredForks[0]?.fullName ?? "")
+  const selectedFork = filteredForks.find((fork) => fork.fullName === selectedForkName) ?? filteredForks[0]
+
+  useEffect(() => {
+    if (filteredForks.length > 0 && !filteredForks.some((f) => f.fullName === selectedForkName)) {
+      setSelectedForkName(filteredForks[0].fullName)
+    }
+  }, [filteredForks, selectedForkName])
+
+  function updateParams(updates: Record<string, string>) {
+    const params = new URLSearchParams(searchParams.toString())
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) {
+        params.set(key, value)
+      } else {
+        params.delete(key)
+      }
+    }
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
+
+  const hasActiveFilters = maintenanceFilter || magnitudeFilter || sortBy
 
   return (
     <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
@@ -302,6 +360,7 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
               <ArrowUpRight className="h-4 w-4" />
             </a>
             <BookmarkButton owner={view.owner} repo={view.repo} variant="button" />
+            <WatchButton owner={view.owner} repo={view.repo} variant="button" />
             <button
               type="button"
               onClick={() => exportRepoBrief(view)}
@@ -333,39 +392,104 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
               <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Forks</div>
               <h3 className="mt-2 text-base font-semibold tracking-tight text-foreground">Choose a fork to inspect</h3>
             </div>
-            <div className="text-xs text-muted-foreground">{view.forks.length} cached fork briefs</div>
+            <div className="text-xs text-muted-foreground">
+              {filteredForks.length} of {view.forks.length} fork briefs
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Filter className="h-3.5 w-3.5 text-muted-foreground" />
+            <div className="flex flex-wrap items-center gap-1.5">
+              <label htmlFor="maintenance-filter" className="text-xs text-muted-foreground">Maintenance:</label>
+              <select
+                id="maintenance-filter"
+                value={maintenanceFilter}
+                onChange={(e) => updateParams({ maintenance: e.target.value })}
+                className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
+              >
+                <option value="">All</option>
+                {allMaintenances.map((m) => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <label htmlFor="magnitude-filter" className="text-xs text-muted-foreground">Magnitude:</label>
+              <select
+                id="magnitude-filter"
+                value={magnitudeFilter}
+                onChange={(e) => updateParams({ magnitude: e.target.value })}
+                className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
+              >
+                <option value="">All</option>
+                {allMagnitudes.map((m) => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <ArrowUpDown className="h-3.5 w-3.5 text-muted-foreground" />
+              <label htmlFor="sort-by" className="text-xs text-muted-foreground">Sort:</label>
+              <select
+                id="sort-by"
+                value={sortBy}
+                onChange={(e) => updateParams({ sort: e.target.value })}
+                className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none focus:border-ring"
+              >
+                <option value="">Default</option>
+                <option value="maintenance">Maintenance</option>
+                <option value="magnitude">Change magnitude</option>
+                <option value="name">Name</option>
+              </select>
+            </div>
+            {hasActiveFilters ? (
+              <button
+                type="button"
+                onClick={() => updateParams({ maintenance: "", magnitude: "", sort: "" })}
+                className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+                Clear
+              </button>
+            ) : null}
           </div>
 
           <div className="mt-5 overflow-hidden rounded-md border border-border">
-            {view.forks.map((fork) => {
-              const active = fork.fullName === selectedFork?.fullName
+            {filteredForks.length === 0 ? (
+              <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+                No forks match the current filters.
+              </div>
+            ) : (
+              filteredForks.map((fork) => {
+                const active = fork.fullName === selectedFork?.fullName
 
-              return (
-                <button
-                  key={fork.fullName}
-                  type="button"
-                  onClick={() => setSelectedForkName(fork.fullName)}
-                  className={cn(
-                    "w-full border-b px-4 py-3 text-left transition-colors last:border-b-0",
-                    active
-                      ? "border-l-2 border-l-primary border-r-0 border-t-0 border-b border-border bg-primary/10"
-                      : "border-l-2 border-l-transparent border-r-0 border-t-0 border-b border-border bg-card hover:bg-muted/70",
-                  )}
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <div className="text-sm font-medium text-foreground">{fork.fullName}</div>
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        <Badge variant={fork.maintenance === "active" ? "success" : "muted"}>{fork.maintenance}</Badge>
-                        <Badge variant="muted">{fork.changeMagnitude}</Badge>
+                return (
+                  <button
+                    key={fork.fullName}
+                    type="button"
+                    onClick={() => setSelectedForkName(fork.fullName)}
+                    className={cn(
+                      "w-full border-b px-4 py-3 text-left transition-colors last:border-b-0",
+                      active
+                        ? "border-l-2 border-l-primary border-r-0 border-t-0 border-b border-border bg-primary/10"
+                        : "border-l-2 border-l-transparent border-r-0 border-t-0 border-b border-border bg-card hover:bg-muted/70",
+                    )}
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-medium text-foreground">{fork.fullName}</div>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Badge variant={fork.maintenance === "active" ? "success" : "muted"}>{fork.maintenance}</Badge>
+                          <Badge variant="muted">{fork.changeMagnitude}</Badge>
+                        </div>
                       </div>
+                      {active ? <span className="text-xs font-medium text-primary">Selected</span> : null}
                     </div>
-                    {active ? <span className="text-xs font-medium text-primary">Selected</span> : null}
-                  </div>
-                  <p className="mt-2 max-w-[100ch] text-sm leading-6 text-muted-foreground">{fork.summary}</p>
-                </button>
-              )
-            })}
+                    <p className="mt-2 max-w-[100ch] text-sm leading-6 text-muted-foreground">{fork.summary}</p>
+                  </button>
+                )
+              })
+            )}
           </div>
         </div>
       </div>

--- a/web/src/components/watch-button.tsx
+++ b/web/src/components/watch-button.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Eye, EyeOff } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { isWatched, toggleWatch } from "@/lib/watches"
+
+export function WatchButton({
+  owner,
+  repo,
+  variant = "icon",
+}: {
+  owner: string
+  repo: string
+  variant?: "icon" | "button"
+}) {
+  const [watched, setWatched] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const fullName = `${owner}/${repo}`
+
+  useEffect(() => {
+    setMounted(true)
+    setWatched(isWatched(fullName))
+  }, [fullName])
+
+  const handleToggle = useCallback(() => {
+    const next = toggleWatch(owner, repo)
+    setWatched(next)
+  }, [owner, repo])
+
+  if (!mounted) {
+    if (variant === "button") {
+      return (
+        <Button variant="outline" className="gap-2 rounded-md px-4" disabled>
+          <Eye className="h-4 w-4" />
+          Watch
+        </Button>
+      )
+    }
+    return (
+      <button
+        type="button"
+        disabled
+        className="rounded-md p-2 text-muted-foreground opacity-50"
+        aria-label="Watch"
+      >
+        <Eye className="h-4 w-4" />
+      </button>
+    )
+  }
+
+  if (variant === "button") {
+    return (
+      <Button
+        variant="outline"
+        onClick={handleToggle}
+        className={cn(
+          "gap-2 rounded-md px-4",
+          watched && "border-blue-500/20 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+        )}
+      >
+        {watched ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        {watched ? "Watching" : "Watch"}
+      </Button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      className={cn(
+        "rounded-md p-2 transition-colors",
+        watched
+          ? "text-blue-500 hover:text-blue-600"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+      aria-label={watched ? "Unwatch" : "Watch"}
+    >
+      {watched ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+    </button>
+  )
+}

--- a/web/src/components/watch-touch.tsx
+++ b/web/src/components/watch-touch.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { useEffect } from "react"
+import { touchWatch } from "@/lib/watches"
+
+export function WatchTouch({ fullName }: { fullName: string }) {
+  useEffect(() => {
+    touchWatch(fullName)
+  }, [fullName])
+
+  return null
+}

--- a/web/src/lib/watches.ts
+++ b/web/src/lib/watches.ts
@@ -1,0 +1,84 @@
+const WATCHES_STORAGE_KEY = "discofork-watches"
+
+export type WatchEntry = {
+  fullName: string
+  owner: string
+  repo: string
+  watchedAt: string
+  lastVisitedAt: string
+}
+
+export function getWatches(): WatchEntry[] {
+  if (typeof window === "undefined") {
+    return []
+  }
+
+  try {
+    const raw = localStorage.getItem(WATCHES_STORAGE_KEY)
+    if (!raw) {
+      return []
+    }
+
+    const parsed = JSON.parse(raw) as WatchEntry[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export function isWatched(fullName: string): boolean {
+  return getWatches().some((entry) => entry.fullName === fullName)
+}
+
+export function addWatch(owner: string, repo: string): WatchEntry {
+  const watches = getWatches()
+  const fullName = `${owner}/${repo}`
+
+  const existing = watches.find((entry) => entry.fullName === fullName)
+  if (existing) {
+    return existing
+  }
+
+  const entry: WatchEntry = {
+    fullName,
+    owner,
+    repo,
+    watchedAt: new Date().toISOString(),
+    lastVisitedAt: new Date().toISOString(),
+  }
+
+  localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify([...watches, entry]))
+  return entry
+}
+
+export function removeWatch(fullName: string): void {
+  const watches = getWatches().filter((entry) => entry.fullName !== fullName)
+  localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify(watches))
+}
+
+export function toggleWatch(owner: string, repo: string): boolean {
+  const fullName = `${owner}/${repo}`
+
+  if (isWatched(fullName)) {
+    removeWatch(fullName)
+    return false
+  }
+
+  addWatch(owner, repo)
+  return true
+}
+
+export function touchWatch(fullName: string): void {
+  const watches = getWatches()
+  const entry = watches.find((e) => e.fullName === fullName)
+  if (entry) {
+    entry.lastVisitedAt = new Date().toISOString()
+    localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify(watches))
+  }
+}
+
+export function hasUpdate(watch: WatchEntry, cachedAt: string): boolean {
+  const watchedDate = new Date(watch.lastVisitedAt)
+  const cachedDate = new Date(cachedAt)
+  return cachedDate > watchedDate
+}


### PR DESCRIPTION
Closes #59

## Why

Visitors to Discofork.ai currently have no way to track repository updates, filter/sort forks on detail pages, or easily queue new repositories for analysis.

## What changed

Three new user-facing features:

1. **Repository Watch/Notifications** — WatchButton on repo detail pages, localStorage-backed watch list, /watched page with last-visited tracking for update detection.

2. **Fork Filtering & Sorting** — Filter forks by maintenance status and change magnitude, sort by maintenance/magnitude/name. Filter state persists in URL parameters for shareable links.

3. **Quick Queue Input** — Prominent QueueInput on home page and repos page empty state. Validates owner/repo format and navigates to repo page.

## Files

- `web/src/lib/watches.ts` — localStorage CRUD for watch entries
- `web/src/components/watch-button.tsx` — Toggle watch UI
- `web/src/components/watch-touch.tsx` — Updates last-visited on repo page load
- `web/src/components/queue-input.tsx` — owner/repo input with validation
- `web/src/app/watched/page.tsx` — Watched repositories page
- `web/src/app/page.tsx` — Added queue input card
- `web/src/app/repos/page.tsx` — Added queue input to empty state
- `web/src/app/[owner]/[repo]/page.tsx` — Added WatchTouch
- `web/src/components/repo-shell.tsx` — Added Watched nav link
- `web/src/components/repository-brief.tsx` — Fork filter/sort controls + WatchButton

## Testing

- `npx bun run typecheck` passes
- Existing bookmarks, export, and compare features unchanged
- No backend changes required

## Out of scope

- Push/browser notification API (uses localStorage badges only)
- Server-side watch persistence (localStorage is sufficient for v1)