### PR TITLE
feat: add keyboard shortcuts, recently viewed history, and repository tags

### DIFF
--- a/web/src/app/[owner]/[repo]/page.tsx
+++ b/web/src/app/[owner]/[repo]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 
 import { CachedRepositoryBrief, QueuedRepositoryBrief } from "@/components/repository-brief"
 import { RepoShell } from "@/components/repo-shell"
+import { HistoryTouch } from "@/components/history-touch"
 import { WatchTouch } from "@/components/watch-touch"
 import { RepositoryNotFoundError, getRepositoryPageView, readRepositoryView } from "@/lib/repository-service"
 import { buildRepoSocialSummary, getSiteOrigin } from "@/lib/repository-social"
@@ -88,6 +89,7 @@ export default async function RepositoryPage({ params }: RepoPageProps) {
       compact
     >
       {view.kind === "cached" ? <CachedRepositoryBrief view={view} /> : <QueuedRepositoryBrief view={view} />}
+      <HistoryTouch fullName={`${owner}/${repo}`} />
       <WatchTouch fullName={`${owner}/${repo}`} />
     </RepoShell>
   )

--- a/web/src/app/recent/page.tsx
+++ b/web/src/app/recent/page.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowRight, Clock, Trash2 } from "lucide-react"
+
+import { RepoShell } from "@/components/repo-shell"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { type HistoryEntry, getHistory, removeHistory, clearHistory } from "@/lib/history"
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return "just now"
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+  return date.toLocaleDateString()
+}
+
+export default function RecentPage() {
+  const [history, setHistory] = useState<HistoryEntry[]>([])
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    setHistory(getHistory())
+  }, [])
+
+  const handleRemove = (fullName: string) => {
+    removeHistory(fullName)
+    setHistory(getHistory())
+  }
+
+  const handleClear = () => {
+    clearHistory()
+    setHistory([])
+  }
+
+  return (
+    <RepoShell
+      eyebrow="Recently Viewed"
+      title="Your browsing history."
+      description="Repositories you have recently visited. History is stored locally in your browser."
+      compact
+    >
+      <section className="space-y-6">
+        {!mounted ? (
+          <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+            Loading history...
+          </div>
+        ) : history.length === 0 ? (
+          <div className="rounded-md border border-border bg-card p-6">
+            <div className="flex items-start gap-4">
+              <Clock className="mt-1 h-5 w-5 text-muted-foreground" />
+              <div className="space-y-3">
+                <h2 className="text-base font-semibold text-foreground">No recent history</h2>
+                <p className="text-sm leading-7 text-muted-foreground">
+                  Repositories you visit will appear here for quick access.
+                </p>
+                <Link
+                  href="/repos"
+                  className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}
+                >
+                  Browse repositories
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">
+                {history.length} recent {history.length === 1 ? "repository" : "repositories"}
+              </span>
+              <button
+                type="button"
+                onClick={handleClear}
+                className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs text-muted-foreground hover:text-rose-500")}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Clear history
+              </button>
+            </div>
+            <div className="overflow-hidden rounded-md border border-border bg-card">
+              {history.map((entry) => (
+                <div
+                  key={entry.fullName}
+                  className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <Link
+                      href={`/${entry.owner}/${entry.repo}`}
+                      className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                    >
+                      {entry.fullName}
+                    </Link>
+                    <div className="text-xs text-muted-foreground">
+                      Viewed {formatRelativeTime(entry.visitedAt)}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Link
+                      href={`/${entry.owner}/${entry.repo}`}
+                      className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
+                    >
+                      Open
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(entry.fullName)}
+                      className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
+                      aria-label={`Remove ${entry.fullName} from history`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </section>
+    </RepoShell>
+  )
+}

--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -8,6 +8,9 @@ import { RepoRowActions } from "@/components/repo-row-actions"
 import { RepoOrderSelect } from "@/components/repo-order-select"
 import { RepoStatusFilter } from "@/components/repo-status-filter"
 import { RepoShell } from "@/components/repo-shell"
+import { TagDisplay } from "@/components/tag-manager"
+import { RepoTagFilter } from "@/components/repo-tag-filter"
+import { RepoListKeyboardProvider } from "@/components/repo-keyboard-provider"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
 import { REPO_LIST_PAGE_SIZE, type RepoListItem, type RepoListOrder, type RepoListStatusFilter, type RepoListView } from "@/lib/repository-list"
@@ -178,6 +181,7 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
     >
       <section className="space-y-6">
         <CompareBar />
+        <RepoTagFilter />
         <div className="space-y-4 rounded-md border border-border bg-card px-5 py-4">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex flex-wrap items-center gap-5 text-sm text-muted-foreground">
@@ -278,11 +282,14 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
             ) : null}
           </div>
         ) : (
-          <div className="overflow-hidden rounded-md border border-border bg-card">
+          <RepoListKeyboardProvider>
+            <div className="overflow-hidden rounded-md border border-border bg-card" data-repo-list>
             {view.items.map((item) => (
               <Link
                 key={item.fullName}
                 href={`/${item.owner}/${item.repo}`}
+                data-repo-item
+                data-full-name={item.fullName}
                 className="block border-b border-border px-5 py-4 transition-colors last:border-b-0 hover:bg-muted/70"
               >
                 <div className="flex flex-wrap items-start justify-between gap-4">
@@ -292,6 +299,7 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
                       <Badge variant={statusVariant(item)}>{statusLabel(item)}</Badge>
                       {item.status === "ready" ? <Badge variant="muted">{item.forkBriefCount} fork briefs</Badge> : null}
                     </div>
+                    <TagDisplay fullName={item.fullName} />
                     <p className="max-w-[120ch] text-sm leading-6 text-muted-foreground">
                       {item.upstreamSummary ?? "No cached upstream summary is available yet."}
                     </p>
@@ -324,7 +332,8 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
                 </div>
               </Link>
             ))}
-          </div>
+            </div>
+          </RepoListKeyboardProvider>
         )}
       </section>
     </RepoShell>

--- a/web/src/components/history-touch.tsx
+++ b/web/src/components/history-touch.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { useEffect } from "react"
+import { addHistory } from "@/lib/history"
+
+export function HistoryTouch({ fullName }: { fullName: string }) {
+  const parts = fullName.split("/")
+  useEffect(() => {
+    if (parts.length === 2) {
+      addHistory(parts[0], parts[1])
+    }
+  }, [fullName, parts])
+
+  return null
+}

--- a/web/src/components/keyboard-help-modal.tsx
+++ b/web/src/components/keyboard-help-modal.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { Keyboard, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+type Shortcut = {
+  keys: string
+  description: string
+}
+
+const shortcuts: Shortcut[] = [
+  { keys: "j / ↓", description: "Move to next item" },
+  { keys: "k / ↑", description: "Move to previous item" },
+  { keys: "Enter", description: "Open selected repository" },
+  { keys: "b", description: "Bookmark selected repository" },
+  { keys: "w", description: "Watch selected repository" },
+  { keys: "c", description: "Add selected to compare" },
+  { keys: "/", description: "Focus search" },
+  { keys: "Esc", description: "Clear selection / close modal" },
+  { keys: "?", description: "Show this help" },
+]
+
+export function KeyboardHelpModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: () => void
+}) {
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Keyboard className="h-5 w-5 text-primary" />
+            <h2 className="text-lg font-semibold text-foreground">Keyboard Shortcuts</h2>
+          </div>
+
+          <div className="space-y-2">
+            {shortcuts.map((shortcut) => (
+              <div
+                key={shortcut.keys}
+                className="flex items-center justify-between rounded-md px-3 py-2 transition-colors hover:bg-muted/50"
+              >
+                <span className="text-sm text-muted-foreground">{shortcut.description}</span>
+                <kbd className="inline-flex items-center gap-1 rounded border border-border bg-muted/70 px-2 py-0.5 font-mono text-xs text-foreground">
+                  {shortcut.keys}
+                </kbd>
+              </div>
+            ))}
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <p className="text-xs text-muted-foreground">
+              Shortcuts are disabled when typing in input fields. Press{" "}
+              <kbd className="rounded border border-border bg-muted/70 px-1.5 py-0.5 font-mono text-[10px]">
+                ?
+              </kbd>{" "}
+              anytime to show this help.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function KeyboardHelpButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        buttonVariants({ variant: "ghost" }),
+        "gap-1.5 px-2 text-xs text-muted-foreground",
+      )}
+      aria-label="Keyboard shortcuts"
+    >
+      <Keyboard className="h-3.5 w-3.5" />
+      <span className="hidden sm:inline">Shortcuts</span>
+      <kbd className="ml-1 rounded border border-border bg-muted/70 px-1.5 py-0.5 font-mono text-[10px]">
+        ?
+      </kbd>
+    </button>
+  )
+}

--- a/web/src/components/repo-keyboard-provider.tsx
+++ b/web/src/components/repo-keyboard-provider.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { KeyboardHelpModal, KeyboardHelpButton } from "@/components/keyboard-help-modal"
+import { useKeyboardShortcuts, useRepoListNavigation } from "@/hooks/use-keyboard-shortcuts"
+import { toggleBookmark } from "@/lib/bookmarks"
+import { toggleWatch } from "@/lib/watches"
+import { toggleCompareRepo } from "@/lib/compare"
+
+export function RepoListKeyboardProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const router = useRouter()
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [items, setItems] = useState<HTMLElement[]>([])
+
+  useEffect(() => {
+    const container = document.querySelector("[data-repo-list]")
+    if (!container) return
+
+    const updateItems = () => {
+      const listItems = Array.from(
+        container.querySelectorAll<HTMLElement>("[data-repo-item]"),
+      )
+      setItems(listItems)
+    }
+
+    updateItems()
+
+    const observer = new MutationObserver(updateItems)
+    observer.observe(container, { childList: true, subtree: true })
+
+    return () => observer.disconnect()
+  }, [])
+
+  const scrollToItem = useCallback((index: number) => {
+    const item = items[index]
+    if (item) {
+      item.scrollIntoView({ behavior: "smooth", block: "nearest" })
+    }
+  }, [items])
+
+  const selectItem = useCallback(
+    (index: number) => {
+      items.forEach((item, i) => {
+        if (i === index) {
+          item.classList.add("bg-muted/70")
+          item.setAttribute("data-selected", "true")
+        } else {
+          item.classList.remove("bg-muted/70")
+          item.removeAttribute("data-selected")
+        }
+      })
+      scrollToItem(index)
+    },
+    [items, scrollToItem],
+  )
+
+  const {
+    selectedIndex,
+    moveDown,
+    moveUp,
+    openSelected,
+    bookmarkSelected,
+    watchSelected,
+    compareSelected,
+    focusSearch,
+    clearSelection,
+  } = useRepoListNavigation({
+    itemCount: items.length,
+    onSelect: selectItem,
+    onOpen: (index) => {
+      const link = items[index]?.querySelector("a")
+      if (link) {
+        router.push(link.getAttribute("href") ?? "")
+      }
+    },
+    onBookmark: (index) => {
+      const fullName = items[index]?.getAttribute("data-full-name")
+      if (fullName) {
+        const [owner, repo] = fullName.split("/")
+        toggleBookmark(owner, repo)
+      }
+    },
+    onWatch: (index) => {
+      const fullName = items[index]?.getAttribute("data-full-name")
+      if (fullName) {
+        const [owner, repo] = fullName.split("/")
+        toggleWatch(owner, repo)
+      }
+    },
+    onCompare: (index) => {
+      const fullName = items[index]?.getAttribute("data-full-name")
+      if (fullName) {
+        toggleCompareRepo(fullName)
+      }
+    },
+  })
+
+  const { } = useKeyboardShortcuts([
+    { key: "j", description: "Move down", action: moveDown, global: true },
+    { key: "ArrowDown", description: "Move down", action: moveDown, global: true },
+    { key: "k", description: "Move up", action: moveUp, global: true },
+    { key: "ArrowUp", description: "Move up", action: moveUp, global: true },
+    { key: "Enter", description: "Open selected", action: openSelected },
+    { key: "b", description: "Bookmark selected", action: bookmarkSelected, global: true },
+    { key: "w", description: "Watch selected", action: watchSelected, global: true },
+    { key: "c", description: "Compare selected", action: compareSelected, global: true },
+    { key: "/", description: "Focus search", action: focusSearch, global: true },
+    { key: "?", description: "Show help", action: () => setHelpOpen(true), global: true },
+    { key: "Escape", description: "Clear selection", action: clearSelection },
+  ])
+
+  return (
+    <>
+      <div className="flex items-center justify-end">
+        <KeyboardHelpButton onClick={() => setHelpOpen(true)} />
+      </div>
+      {children}
+      <KeyboardHelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
+    </>
+  )
+}

--- a/web/src/components/repo-shell.tsx
+++ b/web/src/components/repo-shell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 import Link from "next/link"
-import { ArrowUpRight, Bookmark, Eye } from "lucide-react"
+import { ArrowUpRight, Bookmark, Clock, Eye } from "lucide-react"
 
 import { ThemeToggle } from "@/components/theme-toggle"
 import { buttonVariants } from "@/components/ui/button"
@@ -30,6 +30,10 @@ export function RepoShell({
           <div className="flex flex-wrap items-center gap-2">
             <Link href="/repos" className={cn(buttonVariants({ variant: "ghost" }), "text-muted-foreground")}>
               Repos
+            </Link>
+            <Link href="/recent" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")}>
+              <Clock className="h-4 w-4" />
+              Recent
             </Link>
             <Link href="/bookmarks" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")}>
               <Bookmark className="h-4 w-4" />

--- a/web/src/components/repo-tag-filter.tsx
+++ b/web/src/components/repo-tag-filter.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Tag } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { getAllTags, getReposByTag } from "@/lib/tags"
+
+export function RepoTagFilter({}: {}) {
+  const [allTags, setAllTags] = useState<string[]>([])
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [filteredRepos, setFilteredRepos] = useState<string[]>([])
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    setAllTags(getAllTags())
+  }, [])
+
+  useEffect(() => {
+    if (selectedTag) {
+      setFilteredRepos(getReposByTag(selectedTag))
+    } else {
+      setFilteredRepos([])
+    }
+  }, [selectedTag])
+
+  if (!mounted || allTags.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+          Filter by tag
+        </span>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+              className={cn(
+                "inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                selectedTag === tag
+                  ? "bg-primary/15 text-primary"
+                  : "bg-muted/70 text-muted-foreground hover:bg-muted hover:text-foreground",
+              )}
+            >
+              <Tag className="h-3 w-3" />
+              {tag}
+            </button>
+          ))}
+          {selectedTag ? (
+            <button
+              type="button"
+              onClick={() => setSelectedTag(null)}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-rose-500/10 hover:text-rose-500"
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
+      </div>
+      {selectedTag && filteredRepos.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {filteredRepos.map((fullName) => {
+            const parts = fullName.split("/")
+            return (
+              <Link
+                key={fullName}
+                href={`/${parts[0]}/${parts[1]}`}
+                className="inline-flex items-center gap-1.5 rounded-md bg-muted/70 px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted"
+              >
+                <Tag className="h-3 w-3 text-primary" />
+                {fullName}
+              </Link>
+            )
+          })}
+        </div>
+      ) : selectedTag ? (
+        <p className="text-xs text-muted-foreground">No repositories tagged with &quot;{selectedTag}&quot;</p>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -8,6 +8,7 @@ import { ArrowUpRight, ArrowUpDown, Clock3, Database, Download, Filter, GitFork,
 import { Badge } from "@/components/ui/badge"
 import { BookmarkButton } from "@/components/bookmark-button"
 import { WatchButton } from "@/components/watch-button"
+import { TagManager } from "@/components/tag-manager"
 import { buttonVariants } from "@/components/ui/button"
 import type { CachedRepoView, QueuedRepoView } from "@/lib/repository-service"
 import { exportRepoBrief } from "@/lib/export-brief"
@@ -369,6 +370,10 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
               <Download className="h-4 w-4" />
               Export .md
             </button>
+          </div>
+
+          <div className="mt-4">
+            <TagManager fullName={view.fullName} />
           </div>
 
           <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2 border-t border-border pt-4">

--- a/web/src/components/tag-filter.tsx
+++ b/web/src/components/tag-filter.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Tag, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { getAllTags, getReposByTag } from "@/lib/tags"
+
+export function TagFilter({
+  onFilterChange,
+}: {
+  onFilterChange: (repos: string[]) => void
+}) {
+  const [allTags, setAllTags] = useState<string[]>([])
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    setAllTags(getAllTags())
+  }, [])
+
+  useEffect(() => {
+    if (selectedTag) {
+      onFilterChange(getReposByTag(selectedTag))
+    } else {
+      onFilterChange([])
+    }
+  }, [selectedTag, onFilterChange])
+
+  const handleSelect = (tag: string) => {
+    setSelectedTag(selectedTag === tag ? null : tag)
+  }
+
+  const handleClear = () => {
+    setSelectedTag(null)
+  }
+
+  if (!mounted || allTags.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+        Filter by tag
+      </span>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {allTags.map((tag) => (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => handleSelect(tag)}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+              selectedTag === tag
+                ? "bg-primary/15 text-primary"
+                : "bg-muted/70 text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <Tag className="h-3 w-3" />
+            {tag}
+          </button>
+        ))}
+        {selectedTag ? (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-rose-500/10 hover:text-rose-500"
+          >
+            <X className="h-3 w-3" />
+            Clear
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/tag-manager.tsx
+++ b/web/src/components/tag-manager.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Plus, Tag, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { addTag, getAllTags, getRepoTags, removeTag } from "@/lib/tags"
+
+export function TagManager({ fullName }: { fullName: string }) {
+  const [tags, setTags] = useState<string[]>([])
+  const [allTags, setAllTags] = useState<string[]>([])
+  const [inputValue, setInputValue] = useState("")
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    setMounted(true)
+    setTags(getRepoTags(fullName))
+    setAllTags(getAllTags())
+  }, [fullName])
+
+  const handleAdd = useCallback(
+    (tag: string) => {
+      if (!tag.trim()) return
+      const updated = addTag(fullName, tag)
+      setTags(updated)
+      setAllTags(getAllTags())
+      setInputValue("")
+      setShowSuggestions(false)
+    },
+    [fullName],
+  )
+
+  const handleRemove = useCallback(
+    (tag: string) => {
+      const updated = removeTag(fullName, tag)
+      setTags(updated)
+      setAllTags(getAllTags())
+    },
+    [fullName],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && inputValue.trim()) {
+        e.preventDefault()
+        handleAdd(inputValue)
+      } else if (e.key === "Escape") {
+        setShowSuggestions(false)
+      }
+    },
+    [inputValue, handleAdd],
+  )
+
+  const filteredSuggestions = allTags.filter(
+    (t) => !tags.includes(t) && t.includes(inputValue.toLowerCase().trim()),
+  )
+
+  if (!mounted) {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Tag className="h-3.5 w-3.5" />
+        <span>Loading tags...</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+          >
+            <Tag className="h-3 w-3" />
+            {tag}
+            <button
+              type="button"
+              onClick={() => handleRemove(tag)}
+              className="ml-0.5 rounded-sm p-0.5 transition-colors hover:bg-primary/20"
+              aria-label={`Remove tag ${tag}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <div className="relative">
+          <div className="flex items-center gap-1">
+            <input
+              ref={inputRef}
+              type="text"
+              value={inputValue}
+              onChange={(e) => {
+                setInputValue(e.target.value)
+                setShowSuggestions(true)
+              }}
+              onFocus={() => setShowSuggestions(true)}
+              onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+              onKeyDown={handleKeyDown}
+              placeholder="Add tag..."
+              className="h-6 w-24 rounded-md border border-border bg-background px-2 text-xs outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+            />
+            {inputValue.trim() ? (
+              <button
+                type="button"
+                onClick={() => handleAdd(inputValue)}
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+                aria-label="Add tag"
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </div>
+          {showSuggestions && filteredSuggestions.length > 0 ? (
+            <div className="absolute left-0 top-full z-10 mt-1 w-40 overflow-hidden rounded-md border border-border bg-card shadow-lg">
+              {filteredSuggestions.slice(0, 5).map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  onMouseDown={() => handleAdd(suggestion)}
+                  className="flex w-full items-center gap-1.5 px-3 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <Tag className="h-3 w-3" />
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function TagDisplay({ fullName }: { fullName: string }) {
+  const [tags, setTags] = useState<string[]>([])
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    setTags(getRepoTags(fullName))
+  }, [fullName])
+
+  if (!mounted || tags.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+        >
+          <Tag className="h-3 w-3" />
+          {tag}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/web/src/hooks/use-keyboard-shortcuts.ts
+++ b/web/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,132 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+export type KeyboardAction = {
+  key: string
+  description: string
+  action: () => void
+  modifier?: "ctrl" | "meta" | "shift" | "alt"
+  global?: boolean
+}
+
+export function useKeyboardShortcuts(actions: KeyboardAction[]) {
+  const [helpOpen, setHelpOpen] = useState(false)
+  const actionsRef = useRef(actions)
+  actionsRef.current = actions
+
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    const target = event.target as HTMLElement
+    const isInput =
+      target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      target.isContentEditable
+
+    for (const action of actionsRef.current) {
+      if (action.key !== event.key) continue
+      if (action.global && isInput) continue
+
+      if (action.modifier) {
+        if (action.modifier === "ctrl" && !event.ctrlKey) continue
+        if (action.modifier === "meta" && !event.metaKey) continue
+        if (action.modifier === "shift" && !event.shiftKey) continue
+        if (action.modifier === "alt" && !event.altKey) continue
+      } else if (event.ctrlKey || event.metaKey || event.altKey) {
+        continue
+      }
+
+      if (action.key === "?" && !event.shiftKey) continue
+      if (action.key === "/" && isInput) continue
+
+      event.preventDefault()
+      action.action()
+      return
+    }
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [handleKeyDown])
+
+  return { helpOpen, setHelpOpen }
+}
+
+export function useRepoListNavigation({
+  itemCount,
+  onSelect,
+  onOpen,
+  onBookmark,
+  onWatch,
+  onCompare,
+}: {
+  itemCount: number
+  onSelect: (index: number) => void
+  onOpen: (index: number) => void
+  onBookmark: (index: number) => void
+  onWatch: (index: number) => void
+  onCompare: (index: number) => void
+}) {
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+
+  const moveDown = useCallback(() => {
+    setSelectedIndex((prev) => {
+      const next = prev < itemCount - 1 ? prev + 1 : prev
+      onSelect(next)
+      return next
+    })
+  }, [itemCount, onSelect])
+
+  const moveUp = useCallback(() => {
+    setSelectedIndex((prev) => {
+      const next = prev > 0 ? prev - 1 : 0
+      onSelect(next)
+      return next
+    })
+  }, [onSelect])
+
+  const openSelected = useCallback(() => {
+    if (selectedIndex >= 0) onOpen(selectedIndex)
+  }, [selectedIndex, onOpen])
+
+  const bookmarkSelected = useCallback(() => {
+    if (selectedIndex >= 0) onBookmark(selectedIndex)
+  }, [selectedIndex, onBookmark])
+
+  const watchSelected = useCallback(() => {
+    if (selectedIndex >= 0) onWatch(selectedIndex)
+  }, [selectedIndex, onWatch])
+
+  const compareSelected = useCallback(() => {
+    if (selectedIndex >= 0) onCompare(selectedIndex)
+  }, [selectedIndex, onCompare])
+
+  const focusSearch = useCallback(() => {
+    const searchInput = document.getElementById("repo-query")
+    if (searchInput) {
+      searchInput.focus()
+    }
+  }, [])
+
+  const clearSelection = useCallback(() => {
+    setSelectedIndex(-1)
+    onSelect(-1)
+    const searchInput = document.getElementById("repo-query") as HTMLInputElement | null
+    if (searchInput) {
+      searchInput.blur()
+    }
+  }, [onSelect])
+
+  return {
+    selectedIndex,
+    setSelectedIndex,
+    moveDown,
+    moveUp,
+    openSelected,
+    bookmarkSelected,
+    watchSelected,
+    compareSelected,
+    focusSearch,
+    clearSelection,
+  }
+}

--- a/web/src/lib/history.ts
+++ b/web/src/lib/history.ts
@@ -1,0 +1,64 @@
+const HISTORY_STORAGE_KEY = "discofork-recent-history"
+const MAX_HISTORY_ENTRIES = 20
+
+export type HistoryEntry = {
+  fullName: string
+  owner: string
+  repo: string
+  visitedAt: string
+}
+
+export function getHistory(): HistoryEntry[] {
+  if (typeof window === "undefined") {
+    return []
+  }
+
+  try {
+    const raw = localStorage.getItem(HISTORY_STORAGE_KEY)
+    if (!raw) {
+      return []
+    }
+
+    const parsed = JSON.parse(raw) as HistoryEntry[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export function addHistory(owner: string, repo: string): void {
+  const history = getHistory()
+  const fullName = `${owner}/${repo}`
+  const now = new Date().toISOString()
+
+  const existing = history.find((entry) => entry.fullName === fullName)
+  if (existing) {
+    existing.visitedAt = now
+    const sorted = history.sort(
+      (a, b) => new Date(b.visitedAt).getTime() - new Date(a.visitedAt).getTime(),
+    )
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(sorted))
+    return
+  }
+
+  const entry: HistoryEntry = {
+    fullName,
+    owner,
+    repo,
+    visitedAt: now,
+  }
+
+  const updated = [entry, ...history].slice(0, MAX_HISTORY_ENTRIES)
+  localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(updated))
+}
+
+export function removeHistory(fullName: string): void {
+  const history = getHistory().filter((entry) => entry.fullName !== fullName)
+  localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history))
+}
+
+export function clearHistory(): void {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify([]))
+  }
+}

--- a/web/src/lib/tags.ts
+++ b/web/src/lib/tags.ts
@@ -1,0 +1,73 @@
+const TAGS_STORAGE_KEY = "discofork-tags"
+
+export type TagsMap = Record<string, string[]>
+
+export function getTags(): TagsMap {
+  if (typeof window === "undefined") {
+    return {}
+  }
+
+  try {
+    const raw = localStorage.getItem(TAGS_STORAGE_KEY)
+    if (!raw) {
+      return {}
+    }
+
+    const parsed = JSON.parse(raw) as TagsMap
+    return typeof parsed === "object" && parsed !== null ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function getRepoTags(fullName: string): string[] {
+  const tags = getTags()
+  return tags[fullName] ?? []
+}
+
+export function setRepoTags(fullName: string, repoTags: string[]): void {
+  const tags = getTags()
+  const cleaned = [...new Set(repoTags.map((t) => t.trim().toLowerCase()).filter(Boolean))].sort()
+  if (cleaned.length === 0) {
+    delete tags[fullName]
+  } else {
+    tags[fullName] = cleaned
+  }
+  localStorage.setItem(TAGS_STORAGE_KEY, JSON.stringify(tags))
+}
+
+export function addTag(fullName: string, tag: string): string[] {
+  const current = getRepoTags(fullName)
+  const normalized = tag.trim().toLowerCase()
+  if (!normalized || current.includes(normalized)) {
+    return current
+  }
+  const updated = [...current, normalized].sort()
+  setRepoTags(fullName, updated)
+  return updated
+}
+
+export function removeTag(fullName: string, tag: string): string[] {
+  const current = getRepoTags(fullName)
+  const updated = current.filter((t) => t !== tag)
+  setRepoTags(fullName, updated)
+  return updated
+}
+
+export function getAllTags(): string[] {
+  const tags = getTags()
+  const allTags = new Set<string>()
+  for (const repoTags of Object.values(tags)) {
+    for (const tag of repoTags) {
+      allTags.add(tag)
+    }
+  }
+  return [...allTags].sort()
+}
+
+export function getReposByTag(tag: string): string[] {
+  const tags = getTags()
+  return Object.entries(tags)
+    .filter(([, repoTags]) => repoTags.includes(tag))
+    .map(([fullName]) => fullName)
+}


### PR DESCRIPTION
## Summary

Closes #61

Adds three user-facing productivity features to the Discofork web app:

### 1. Recently Viewed History
- Repositories are automatically tracked when visited
- New  page shows history with relative timestamps
- "Recent" link added to navigation bar
- Clear history option available
- Max 20 entries stored in localStorage

### 2. Repository Tags
- Add/remove custom tags per repository from detail pages
- Tag autocomplete from existing tags
- Filter repositories by tags on  page
- Tags display on repo cards in the index
- Tags stored in localStorage

### 3. Keyboard Shortcuts
- `j`/`k` or arrow keys to navigate repo list items
- `Enter` to open selected repository
- `b` to bookmark selected, `w` to watch selected
- `c` to add selected to compare
- `/` to focus search input
- `?` to show keyboard shortcuts help modal
- `Escape` to clear selection/close modal
- Shortcuts are disabled when typing in input fields

## Validation
- `npx bun run typecheck` passes
- All features follow existing codebase patterns (localStorage, Tailwind, lucide-react icons)
- No backend changes required
- No new npm dependencies

## Files Changed
- **New:** web/src/lib/history.ts, web/src/lib/tags.ts
- **New:** web/src/components/history-touch.tsx, tag-manager.tsx, tag-filter.tsx, repo-tag-filter.tsx
- **New:** web/src/components/keyboard-help-modal.tsx, repo-keyboard-provider.tsx
- **New:** web/src/hooks/use-keyboard-shortcuts.ts
- **New:** web/src/app/recent/page.tsx
- **Modified:** web/src/components/repo-shell.tsx (Recent nav link)
- **Modified:** web/src/app/repos/page.tsx (tag filter, tag display, keyboard provider)
- **Modified:** web/src/app/[owner]/[repo]/page.tsx (history tracking)
- **Modified:** web/src/components/repository-brief.tsx (tag manager)