### PR TITLE
Add fork scoring, repository notes, and shareable snapshot links

### DIFF
--- a/web/src/app/notes/page.tsx
+++ b/web/src/app/notes/page.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { StickyNote, Trash2, ExternalLink } from "lucide-react"
+import { RepoShell } from "@/components/repo-shell"
+import { getAllNotesWithRepos, removeNote } from "@/lib/notes"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export default function NotesPage() {
+  const [notes, setNotes] = useState<Array<{ fullName: string; note: string }>>([])
+
+  useEffect(() => {
+    setNotes(getAllNotesWithRepos())
+  }, [])
+
+  const handleDelete = (fullName: string) => {
+    removeNote(fullName)
+    setNotes(getAllNotesWithRepos())
+  }
+
+  return (
+    <RepoShell
+      eyebrow="Notes"
+      title="Your notes"
+      description="Personal notes you've added to repositories and forks."
+    >
+      {notes.length === 0 ? (
+        <div className="rounded-md border border-border bg-card p-8 text-center">
+          <StickyNote className="mx-auto h-8 w-8 text-muted-foreground" />
+          <p className="mt-3 text-sm text-muted-foreground">
+            No notes yet. Add notes from any repository or fork detail page.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {notes.map(({ fullName, note }) => (
+            <div
+              key={fullName}
+              className="rounded-md border border-border bg-card p-4"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <StickyNote className="h-4 w-4 text-amber-500" />
+                  <Link
+                    href={`/${fullName}`}
+                    className="text-sm font-medium text-foreground hover:text-primary transition-colors"
+                  >
+                    {fullName}
+                  </Link>
+                  <ExternalLink className="h-3 w-3 text-muted-foreground" />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(fullName)}
+                  className="text-muted-foreground transition-colors hover:text-destructive"
+                  title="Delete note"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground whitespace-pre-wrap">
+                {note}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </RepoShell>
+  )
+}

--- a/web/src/components/note-editor.tsx
+++ b/web/src/components/note-editor.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { StickyNote, X, Pencil } from "lucide-react"
+import { getNote, setNote, hasNote } from "@/lib/notes"
+
+export function NoteEditor({
+  fullName,
+  variant = "inline",
+}: {
+  fullName: string
+  variant?: "inline" | "compact"
+}) {
+  const [text, setText] = useState("")
+  const [editing, setEditing] = useState(false)
+  const [hasExistingNote, setHasExistingNote] = useState(false)
+
+  useEffect(() => {
+    const existing = getNote(fullName)
+    setText(existing)
+    setHasExistingNote(hasNote(fullName))
+  }, [fullName])
+
+  const save = () => {
+    setNote(fullName, text)
+    setHasExistingNote(hasNote(fullName))
+    setEditing(false)
+  }
+
+  const clear = () => {
+    setText("")
+    setNote(fullName, "")
+    setHasExistingNote(false)
+    setEditing(false)
+  }
+
+  if (variant === "compact") {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(!editing)}
+        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        title={hasExistingNote ? "Edit note" : "Add note"}
+      >
+        <StickyNote className={`h-3.5 w-3.5 ${hasExistingNote ? "fill-current text-amber-500" : ""}`} />
+        {hasExistingNote ? "Note" : "Add note"}
+      </button>
+    )
+  }
+
+  if (!editing && !hasExistingNote) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <StickyNote className="h-3.5 w-3.5" />
+        Add note
+      </button>
+    )
+  }
+
+  if (!editing && hasExistingNote) {
+    return (
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <StickyNote className="h-3.5 w-3.5 text-amber-500" />
+          <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Note</span>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            title="Edit note"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground whitespace-pre-wrap">{text}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <StickyNote className="h-3.5 w-3.5 text-amber-500" />
+        <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+          {hasExistingNote ? "Edit note" : "Add note"}
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            setText(getNote(fullName))
+            setEditing(false)
+          }}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+          title="Cancel"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Add your personal note..."
+        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-ring min-h-[80px]"
+        rows={3}
+      />
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={save}
+          className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Save
+        </button>
+        {hasExistingNote ? (
+          <button
+            type="button"
+            onClick={clear}
+            className="rounded-md px-3 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Delete
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/repo-shell.tsx
+++ b/web/src/components/repo-shell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 import Link from "next/link"
-import { ArrowUpRight, Bookmark, Clock, Eye } from "lucide-react"
+import { ArrowUpRight, Bookmark, Clock, Eye, StickyNote } from "lucide-react"
 
 import { ThemeToggle } from "@/components/theme-toggle"
 import { buttonVariants } from "@/components/ui/button"
@@ -42,6 +42,10 @@ export function RepoShell({
             <Link href="/watched" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")}>
               <Eye className="h-4 w-4" />
               Watched
+            </Link>
+            <Link href="/notes" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")}>
+              <StickyNote className="h-4 w-4" />
+              Notes
             </Link>
             <Link href="/compare" className={cn(buttonVariants({ variant: "ghost" }), "text-muted-foreground")}>
               Compare

--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -3,16 +3,20 @@
 import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams, usePathname } from "next/navigation"
-import { ArrowUpRight, ArrowUpDown, Clock3, Database, Download, Filter, GitFork, Radar, Star, X } from "lucide-react"
+import { ArrowUpRight, ArrowUpDown, Clock3, Database, Download, Filter, GitFork, Radar, Star, StickyNote, X } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { BookmarkButton } from "@/components/bookmark-button"
 import { WatchButton } from "@/components/watch-button"
 import { TagManager } from "@/components/tag-manager"
+import { NoteEditor } from "@/components/note-editor"
+import { ShareSnapshotButton } from "@/components/share-snapshot-button"
 import { buttonVariants } from "@/components/ui/button"
 import type { CachedRepoView, QueuedRepoView } from "@/lib/repository-service"
 import { exportRepoBrief } from "@/lib/export-brief"
 import { cn } from "@/lib/utils"
+import { calculateForkScore, getScoreBadgeVariant } from "@/lib/fork-score"
+import { hasNote } from "@/lib/notes"
 
 function SectionList({ title, items }: { title: string; items: string[] }) {
   return (
@@ -282,6 +286,7 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
   const maintenanceFilter = searchParams.get("maintenance") ?? ""
   const magnitudeFilter = searchParams.get("magnitude") ?? ""
   const sortBy = searchParams.get("sort") ?? ""
+  const forkParam = searchParams.get("fork") ?? ""
 
   const allMaintenances = useMemo(
     () => [...new Set(view.forks.map((f) => f.maintenance))].sort(),
@@ -307,12 +312,16 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
       result = [...result].sort((a, b) => a.changeMagnitude.localeCompare(b.changeMagnitude))
     } else if (sortBy === "name") {
       result = [...result].sort((a, b) => a.fullName.localeCompare(b.fullName))
+    } else if (sortBy === "score") {
+      result = [...result].sort((a, b) => calculateForkScore(b) - calculateForkScore(a))
     }
 
     return result
   }, [view.forks, maintenanceFilter, magnitudeFilter, sortBy])
 
-  const [selectedForkName, setSelectedForkName] = useState(filteredForks[0]?.fullName ?? "")
+  const [selectedForkName, setSelectedForkName] = useState(
+    forkParam && view.forks.some((f) => f.fullName === forkParam) ? forkParam : filteredForks[0]?.fullName ?? ""
+  )
   const selectedFork = filteredForks.find((fork) => fork.fullName === selectedForkName) ?? filteredForks[0]
 
   useEffect(() => {
@@ -333,7 +342,7 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
     router.replace(`${pathname}?${params.toString()}`, { scroll: false })
   }
 
-  const hasActiveFilters = maintenanceFilter || magnitudeFilter || sortBy
+  const hasActiveFilters = maintenanceFilter || magnitudeFilter || sortBy || forkParam
 
   return (
     <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
@@ -370,10 +379,15 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
               <Download className="h-4 w-4" />
               Export .md
             </button>
+            <ShareSnapshotButton />
           </div>
 
           <div className="mt-4">
             <TagManager fullName={view.fullName} />
+          </div>
+
+          <div className="mt-3">
+            <NoteEditor fullName={view.fullName} />
           </div>
 
           <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2 border-t border-border pt-4">
@@ -445,12 +459,13 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
                 <option value="maintenance">Maintenance</option>
                 <option value="magnitude">Change magnitude</option>
                 <option value="name">Name</option>
+                <option value="score">Score</option>
               </select>
             </div>
             {hasActiveFilters ? (
               <button
                 type="button"
-                onClick={() => updateParams({ maintenance: "", magnitude: "", sort: "" })}
+                onClick={() => updateParams({ maintenance: "", magnitude: "", sort: "", fork: "" })}
                 className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
               >
                 <X className="h-3 w-3" />
@@ -472,7 +487,12 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
                   <button
                     key={fork.fullName}
                     type="button"
-                    onClick={() => setSelectedForkName(fork.fullName)}
+                    onClick={() => {
+                      setSelectedForkName(fork.fullName)
+                      const params = new URLSearchParams(searchParams.toString())
+                      params.set("fork", fork.fullName)
+                      router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+                    }}
                     className={cn(
                       "w-full border-b px-4 py-3 text-left transition-colors last:border-b-0",
                       active
@@ -482,8 +502,14 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
                   >
                     <div className="flex flex-wrap items-start justify-between gap-3">
                       <div>
-                        <div className="text-sm font-medium text-foreground">{fork.fullName}</div>
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-sm font-medium text-foreground">{fork.fullName}</span>
+                          {hasNote(fork.fullName) ? (
+                            <StickyNote className="h-3 w-3 text-amber-500" title="Has note" />
+                          ) : null}
+                        </div>
                         <div className="mt-2 flex flex-wrap gap-2">
+                          <Badge variant={getScoreBadgeVariant(calculateForkScore(fork))}>{calculateForkScore(fork)}/100</Badge>
                           <Badge variant={fork.maintenance === "active" ? "success" : "muted"}>{fork.maintenance}</Badge>
                           <Badge variant="muted">{fork.changeMagnitude}</Badge>
                         </div>
@@ -507,11 +533,13 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold tracking-tight text-foreground">{selectedFork.fullName}</h3>
                 <div className="flex flex-wrap gap-2">
+                  <Badge variant={getScoreBadgeVariant(calculateForkScore(selectedFork))}>{calculateForkScore(selectedFork)}/100</Badge>
                   <Badge variant={selectedFork.maintenance === "active" ? "success" : "muted"}>{selectedFork.maintenance}</Badge>
                   <Badge variant="muted">{selectedFork.changeMagnitude}</Badge>
                 </div>
                 <p className="text-[15px] leading-7 text-muted-foreground">{selectedFork.summary}</p>
               </div>
+              <NoteEditor fullName={selectedFork.fullName} />
             </div>
 
             <section className="space-y-4 rounded-md border border-border bg-muted/70 p-5">

--- a/web/src/components/share-snapshot-button.tsx
+++ b/web/src/components/share-snapshot-button.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useState } from "react"
+import { useSearchParams, usePathname } from "next/navigation"
+import { Share2, Check } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+export function ShareSnapshotButton() {
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  const [copied, setCopied] = useState(false)
+
+  const handleShare = async () => {
+    // Capture current view state: selected fork, filters, sort
+    const params = new URLSearchParams()
+    const fork = searchParams.get("fork")
+    const maintenance = searchParams.get("maintenance")
+    const magnitude = searchParams.get("magnitude")
+    const sort = searchParams.get("sort")
+
+    if (fork) params.set("fork", fork)
+    if (maintenance) params.set("maintenance", maintenance)
+    if (magnitude) params.set("magnitude", magnitude)
+    if (sort) params.set("sort", sort)
+
+    const queryString = params.toString()
+    const url = typeof window !== "undefined"
+      ? `${window.location.origin}${pathname}${queryString ? `?${queryString}` : ""}`
+      : `${pathname}${queryString ? `?${queryString}` : ""}`
+
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback: select text in a temporary input
+      const input = document.createElement("input")
+      input.value = url
+      document.body.appendChild(input)
+      input.select()
+      document.execCommand("copy")
+      document.body.removeChild(input)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}
+      title="Copy shareable link with current view state"
+    >
+      {copied ? (
+        <>
+          <Check className="h-4 w-4" />
+          Copied!
+        </>
+      ) : (
+        <>
+          <Share2 className="h-4 w-4" />
+          Share view
+        </>
+      )}
+    </button>
+  )
+}

--- a/web/src/lib/fork-score.ts
+++ b/web/src/lib/fork-score.ts
@@ -1,0 +1,56 @@
+/**
+ * Composite fork score (0-100) calculated client-side from
+ * maintenance status, change magnitude, and feature assessment signals.
+ */
+
+const MAINTENANCE_SCORES: Record<string, number> = {
+  active: 100,
+  slowing: 60,
+  stale: 20,
+  unknown: 40,
+}
+
+const MAGNITUDE_SCORES: Record<string, number> = {
+  "minor divergence": 90,
+  "moderate divergence": 70,
+  "significant divergence": 40,
+  unknown: 50,
+}
+
+type ForkSignals = {
+  maintenance: string
+  changeMagnitude: string
+  additionalFeatures: string[]
+  missingFeatures: string[]
+  strengths: string[]
+  risks: string[]
+}
+
+export function calculateForkScore(fork: ForkSignals): number {
+  const maintenanceScore = MAINTENANCE_SCORES[fork.maintenance.toLowerCase()] ?? MAINTENANCE_SCORES.unknown
+  const magnitudeScore = MAGNITUDE_SCORES[fork.changeMagnitude.toLowerCase()] ?? MAGNITUDE_SCORES.unknown
+
+  // Feature richness: more features and strengths = higher score, more missing/risks = lower
+  const featureBonus = Math.min(20, fork.additionalFeatures.length * 4 + fork.strengths.length * 3)
+  const riskPenalty = Math.min(20, fork.missingFeatures.length * 4 + fork.risks.length * 3)
+
+  // Weighted composite: maintenance 40%, magnitude 30%, feature assessment 30%
+  const raw = maintenanceScore * 0.4 + magnitudeScore * 0.3 + (50 + featureBonus - riskPenalty) * 0.3
+
+  return Math.round(Math.max(0, Math.min(100, raw)))
+}
+
+export type ScoreColor = "green" | "yellow" | "red"
+
+export function getScoreColor(score: number): ScoreColor {
+  if (score >= 70) return "green"
+  if (score >= 40) return "yellow"
+  return "red"
+}
+
+export function getScoreBadgeVariant(score: number): "success" | "warning" | "destructive" {
+  const color = getScoreColor(score)
+  if (color === "green") return "success"
+  if (color === "yellow") return "warning"
+  return "destructive"
+}

--- a/web/src/lib/notes.ts
+++ b/web/src/lib/notes.ts
@@ -1,0 +1,60 @@
+/**
+ * Personal notes on repositories and forks, stored in localStorage.
+ * Follows the same pattern as tags.ts — keyed by fullName.
+ */
+
+const NOTES_STORAGE_KEY = "discofork-notes"
+
+export type NotesMap = Record<string, string>
+
+export function getNotes(): NotesMap {
+  if (typeof window === "undefined") {
+    return {}
+  }
+
+  try {
+    const raw = localStorage.getItem(NOTES_STORAGE_KEY)
+    if (!raw) {
+      return {}
+    }
+
+    const parsed = JSON.parse(raw) as NotesMap
+    return typeof parsed === "object" && parsed !== null ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function getNote(fullName: string): string {
+  const notes = getNotes()
+  return notes[fullName] ?? ""
+}
+
+export function setNote(fullName: string, text: string): void {
+  const notes = getNotes()
+  if (text.trim()) {
+    notes[fullName] = text
+  } else {
+    delete notes[fullName]
+  }
+  localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(notes))
+}
+
+export function removeNote(fullName: string): void {
+  const notes = getNotes()
+  delete notes[fullName]
+  localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(notes))
+}
+
+export function hasNote(fullName: string): boolean {
+  const notes = getNotes()
+  return Boolean(notes[fullName]?.trim())
+}
+
+export function getAllNotesWithRepos(): Array<{ fullName: string; note: string }> {
+  const notes = getNotes()
+  return Object.entries(notes)
+    .filter(([, note]) => note.trim())
+    .map(([fullName, note]) => ({ fullName, note }))
+    .sort((a, b) => a.fullName.localeCompare(b.fullName))
+}


### PR DESCRIPTION
Closes #63

## Summary

Adds three user-facing features to the Discofork web app:

1. **Fork Score/Rating** — Composite 0-100 score calculated from maintenance status (40%), change magnitude (30%), and feature assessment (30%). Scores are color-coded (green ≥70, yellow ≥40, red <40) and displayed as badges on fork items. Sortable by score.

2. **Repository/Fork Notes** — Personal notes stored in localStorage with inline editing UI. Notes page at /notes lists all notes. Sticky note indicator on repos/forks that have notes. Notes link added to site navigation.

3. **Shareable Snapshot Links** — "Share view" button copies a URL capturing the selected fork, maintenance filter, magnitude filter, and sort state. Visiting a shared link restores the exact view state.

## Implementation

- Client-side only (no backend changes)
- Follows established patterns: bookmarks.ts, tags.ts, watches.ts
- `web/src/lib/fork-score.ts` — scoring logic
- `web/src/lib/notes.ts` — localStorage CRUD
- `web/src/components/note-editor.tsx` — inline note editing UI
- `web/src/components/share-snapshot-button.tsx` — clipboard share button
- `web/src/app/notes/page.tsx` — notes listing page

## Validation

- `npx bun run typecheck` — passed
- All three features tested manually
