### PR TITLE
fix: remove unsupported title prop from StickyNote icon

### DIFF
--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -505,7 +505,7 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
                         <div className="flex items-center gap-1.5">
                           <span className="text-sm font-medium text-foreground">{fork.fullName}</span>
                           {hasNote(fork.fullName) ? (
-                            <StickyNote className="h-3 w-3 text-amber-500" title="Has note" />
+                            <span title="Has note"><StickyNote className="h-3 w-3 text-amber-500" /></span>
                           ) : null}
                         </div>
                         <div className="mt-2 flex flex-wrap gap-2">


### PR DESCRIPTION
Fixes TypeScript build error from PR #64.

Lucide-react icons do not accept HTML `title` attributes directly. Wrapped the `StickyNote` icon in a `<span>` element with the title instead.

Fixes Railway build failure:
```
Type error: Property 'title' does not exist on type 'IntrinsicAttributes & Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>'.
```