### PR TITLE
fix: use valid Badge variant for low fork scores

### DIFF
--- a/web/src/lib/fork-score.ts
+++ b/web/src/lib/fork-score.ts
@@ -48,9 +48,9 @@ export function getScoreColor(score: number): ScoreColor {
   return "red"
 }
 
-export function getScoreBadgeVariant(score: number): "success" | "warning" | "destructive" {
+export function getScoreBadgeVariant(score: number): "success" | "warning" | "muted" {
   const color = getScoreColor(score)
   if (color === "green") return "success"
   if (color === "yellow") return "warning"
-  return "destructive"
+  return "muted"
 }


### PR DESCRIPTION
Fixes TypeScript build error from PR #64.

The `getScoreBadgeVariant` function was returning `"destructive"` for red scores, but the Badge component only supports `default`, `muted`, `success`, and `warning` variants.

Changed to return `"muted"` for low scores instead.

Fixes Railway build failure:
```
Type error: Type '"success" | "warning" | "destructive"' is not assignable to type '"muted" | "default" | "success" | "warning" | null | undefined'.
```