### PR TITLE
feat: add 'Copy as JSON' button to repository brief

### DIFF
--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams, usePathname } from "next/navigation"
-import { ArrowUpRight, ArrowUpDown, Clock3, Database, Download, Filter, GitFork, Radar, Star, StickyNote, X } from "lucide-react"
+import { ArrowUpRight, ArrowUpDown, Check, Clock3, Database, Download, Filter, GitFork, Radar, Star, StickyNote, X } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { BookmarkButton } from "@/components/bookmark-button"
@@ -13,7 +13,7 @@ import { NoteEditor } from "@/components/note-editor"
 import { ShareSnapshotButton } from "@/components/share-snapshot-button"
 import { buttonVariants } from "@/components/ui/button"
 import type { CachedRepoView, QueuedRepoView } from "@/lib/repository-service"
-import { exportRepoBrief } from "@/lib/export-brief"
+import { exportRepoBrief, generateBriefJson } from "@/lib/export-brief"
 import { cn } from "@/lib/utils"
 import { calculateForkScore, getScoreBadgeVariant } from "@/lib/fork-score"
 import { hasNote } from "@/lib/notes"
@@ -282,6 +282,27 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const [jsonCopied, setJsonCopied] = useState(false)
+
+  const handleCopyJson = async () => {
+    const json = generateBriefJson(view)
+    try {
+      await navigator.clipboard.writeText(json)
+      setJsonCopied(true)
+      setTimeout(() => setJsonCopied(false), 2000)
+    } catch {
+      const textarea = document.createElement("textarea")
+      textarea.value = json
+      textarea.style.position = "fixed"
+      textarea.style.opacity = "0"
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand("copy")
+      document.body.removeChild(textarea)
+      setJsonCopied(true)
+      setTimeout(() => setJsonCopied(false), 2000)
+    }
+  }
 
   const maintenanceFilter = searchParams.get("maintenance") ?? ""
   const magnitudeFilter = searchParams.get("magnitude") ?? ""
@@ -378,6 +399,23 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
             >
               <Download className="h-4 w-4" />
               Export .md
+            </button>
+            <button
+              type="button"
+              onClick={handleCopyJson}
+              className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-3 py-2 text-sm sm:px-4")}
+            >
+              {jsonCopied ? (
+                <>
+                  <Check className="h-4 w-4" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4" />
+                  Copy .json
+                </>
+              )}
             </button>
             <ShareSnapshotButton />
           </div>

--- a/web/src/lib/export-brief.ts
+++ b/web/src/lib/export-brief.ts
@@ -116,6 +116,42 @@ export function downloadBriefMarkdown(view: CachedRepoView): void {
   URL.revokeObjectURL(url)
 }
 
+export function generateBriefJson(view: CachedRepoView): string {
+  const data = {
+    exportedAt: new Date().toISOString(),
+    repository: view.fullName,
+    source: view.githubUrl,
+    cachedAt: view.cachedAt,
+    summary: view.upstreamSummary,
+    stats: {
+      stars: view.stats.stars,
+      forks: view.stats.forks,
+      defaultBranch: view.stats.defaultBranch,
+      lastPushedAt: view.stats.lastPushedAt,
+    },
+    recommendations: {
+      bestMaintained: view.recommendations.bestMaintained,
+      closestToUpstream: view.recommendations.closestToUpstream,
+      mostFeatureRich: view.recommendations.mostFeatureRich,
+      mostOpinionated: view.recommendations.mostOpinionated,
+    },
+    forks: view.forks.map((fork) => ({
+      fullName: fork.fullName,
+      maintenance: fork.maintenance,
+      changeMagnitude: fork.changeMagnitude,
+      summary: fork.summary,
+      likelyPurpose: fork.likelyPurpose,
+      bestFor: fork.bestFor,
+      additionalFeatures: fork.additionalFeatures,
+      missingFeatures: fork.missingFeatures,
+      strengths: fork.strengths,
+      risks: fork.risks,
+    })),
+  }
+
+  return JSON.stringify(data, null, 2)
+}
+
 export function exportRepoBrief(view: CachedRepoView): void {
   downloadBriefMarkdown(view)
 }


### PR DESCRIPTION
Closes #70

## Summary

Add a "Copy as JSON" button alongside the existing Markdown export on cached repository brief pages, allowing users to copy structured analysis data to their clipboard.

## What changed

- Added `generateBriefJson()` function to `web/src/lib/export-brief.ts` that produces pretty-printed JSON with all analysis data (upstream summary, stats, recommendations, and full fork analysis)
- Added "Copy as JSON" button to the cached repository brief toolbar in `web/src/components/repository-brief.tsx`
- Button uses navigator.clipboard with textarea fallback (matching the existing ShareSnapshotButton pattern)
- Shows "Copied!" confirmation with check icon for 2 seconds after copying

## Why

The existing Markdown export is great for documentation but hard to parse programmatically. Users who want to share Discofork data in structured form (scripts, databases, chat) previously had no quick path from the web UI.

## Validation

- ✅ `npx bun run typecheck` (root) — passed
- ✅ `npx bun run typecheck` (web) — passed  
- ✅ `npx bun run build` (web) — passed, all routes healthy

## Risks

- Minimal: two files touched, pure client-side addition, no backend changes
- The button reuses the same Download icon as the Markdown export; the label text "Copy .json" distinguishes it
