### PR TITLE
refactor: extract localStorage boilerplate into shared utility

### DIFF
--- a/.hermes/plans/2026-04-13-extract-localstorage-boilerplate.md
+++ b/.hermes/plans/2026-04-13-extract-localstorage-boilerplate.md
@@ -1,0 +1,35 @@
+# ExecPlan: Extract localStorage boilerplate into shared utility
+
+## Goal
+
+Eliminate duplicated SSR-safe localStorage boilerplate across 5+ files by creating a generic factory utility.
+
+## Why
+
+Each localStorage file (bookmarks, watches, history, notes, tags) duplicated the same SSR detection, try/catch, and JSON.parse pattern. Any change to this pattern (e.g., adding error logging, changing SSR behavior) would require updating every file independently. This refactor creates a single source of truth.
+
+## Current observations
+
+- `web/src/lib/bookmarks.ts`, `watches.ts`, `history.ts`, `notes.ts`, `tags.ts` all had ~15 lines of identical boilerplate
+- Two patterns exist: array-based stores and map-based stores
+- `compare.ts` was left unchanged because it interleaves URL parameter logic with localStorage
+
+## Files changed
+
+- `web/src/lib/local-storage.ts` — new shared factory with `createArrayStore` and `createMapStore`
+- `web/src/lib/bookmarks.ts` — refactored to use `createArrayStore`
+- `web/src/lib/watches.ts` — refactored to use `createArrayStore` (keeps `touchWatch` and `hasUpdate`)
+- `web/src/lib/history.ts` — refactored to use `createArrayStore` (keeps custom `addHistory` with max-entries and sorting)
+- `web/src/lib/notes.ts` — refactored to use `createMapStore`
+- `web/src/lib/tags.ts` — refactored to use `createMapStore` (keeps all tag-specific logic)
+
+## Validation
+
+- `npx bun run typecheck` in web/ — passed
+- `npx bun run typecheck` in root — passed
+- `npx bun test` — 104 pass, 0 fail
+
+## Risks
+
+- None behavioral: all public APIs are preserved identically
+- SSR behavior unchanged (returns empty on server)

--- a/web/src/lib/bookmarks.ts
+++ b/web/src/lib/bookmarks.ts
@@ -1,4 +1,4 @@
-const BOOKMARKS_STORAGE_KEY = "discofork-bookmarks"
+import { createArrayStore } from "./local-storage"
 
 export type BookmarkEntry = {
   fullName: string
@@ -7,60 +7,19 @@ export type BookmarkEntry = {
   bookmarkedAt: string
 }
 
-export function getBookmarks(): BookmarkEntry[] {
-  if (typeof window === "undefined") {
-    return []
-  }
-
-  try {
-    const raw = localStorage.getItem(BOOKMARKS_STORAGE_KEY)
-    if (!raw) {
-      return []
-    }
-
-    const parsed = JSON.parse(raw) as BookmarkEntry[]
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-export function isBookmarked(fullName: string): boolean {
-  return getBookmarks().some((entry) => entry.fullName === fullName)
-}
-
-export function addBookmark(owner: string, repo: string): BookmarkEntry {
-  const bookmarks = getBookmarks()
-  const fullName = `${owner}/${repo}`
-
-  if (bookmarks.some((entry) => entry.fullName === fullName)) {
-    return bookmarks.find((entry) => entry.fullName === fullName)!
-  }
-
-  const entry: BookmarkEntry = {
-    fullName,
+const store = createArrayStore<BookmarkEntry>({
+  storageKey: "discofork-bookmarks",
+  keyOf: (entry) => entry.fullName,
+  createEntry: (owner, repo) => ({
+    fullName: `${owner}/${repo}`,
     owner,
     repo,
     bookmarkedAt: new Date().toISOString(),
-  }
+  }),
+})
 
-  localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify([...bookmarks, entry]))
-  return entry
-}
-
-export function removeBookmark(fullName: string): void {
-  const bookmarks = getBookmarks().filter((entry) => entry.fullName !== fullName)
-  localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(bookmarks))
-}
-
-export function toggleBookmark(owner: string, repo: string): boolean {
-  const fullName = `${owner}/${repo}`
-
-  if (isBookmarked(fullName)) {
-    removeBookmark(fullName)
-    return false
-  }
-
-  addBookmark(owner, repo)
-  return true
-}
+export const getBookmarks = store.getAll
+export const isBookmarked = store.has
+export const addBookmark = store.add
+export const removeBookmark = store.remove
+export const toggleBookmark = store.toggle

--- a/web/src/lib/history.ts
+++ b/web/src/lib/history.ts
@@ -1,3 +1,5 @@
+import { createArrayStore } from "./local-storage"
+
 const HISTORY_STORAGE_KEY = "discofork-recent-history"
 const MAX_HISTORY_ENTRIES = 20
 
@@ -8,24 +10,23 @@ export type HistoryEntry = {
   visitedAt: string
 }
 
-export function getHistory(): HistoryEntry[] {
-  if (typeof window === "undefined") {
-    return []
-  }
+const store = createArrayStore<HistoryEntry>({
+  storageKey: HISTORY_STORAGE_KEY,
+  keyOf: (entry) => entry.fullName,
+  createEntry: (owner, repo) => ({
+    fullName: `${owner}/${repo}`,
+    owner,
+    repo,
+    visitedAt: new Date().toISOString(),
+  }),
+})
 
-  try {
-    const raw = localStorage.getItem(HISTORY_STORAGE_KEY)
-    if (!raw) {
-      return []
-    }
+export const getHistory = store.getAll
+export const removeHistory = store.remove
 
-    const parsed = JSON.parse(raw) as HistoryEntry[]
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
+/**
+ * Add or update a history entry with max-entries cap and recency sorting.
+ */
 export function addHistory(owner: string, repo: string): void {
   const history = getHistory()
   const fullName = `${owner}/${repo}`
@@ -34,10 +35,10 @@ export function addHistory(owner: string, repo: string): void {
   const existing = history.find((entry) => entry.fullName === fullName)
   if (existing) {
     existing.visitedAt = now
-    const sorted = history.sort(
-      (a, b) => new Date(b.visitedAt).getTime() - new Date(a.visitedAt).getTime(),
-    )
-    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(sorted))
+    history.sort((a, b) => new Date(b.visitedAt).getTime() - new Date(a.visitedAt).getTime())
+    if (typeof window !== "undefined") {
+      localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history))
+    }
     return
   }
 
@@ -49,12 +50,9 @@ export function addHistory(owner: string, repo: string): void {
   }
 
   const updated = [entry, ...history].slice(0, MAX_HISTORY_ENTRIES)
-  localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(updated))
-}
-
-export function removeHistory(fullName: string): void {
-  const history = getHistory().filter((entry) => entry.fullName !== fullName)
-  localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history))
+  if (typeof window !== "undefined") {
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(updated))
+  }
 }
 
 export function clearHistory(): void {

--- a/web/src/lib/local-storage.ts
+++ b/web/src/lib/local-storage.ts
@@ -1,0 +1,144 @@
+/**
+ * Generic SSR-safe localStorage store factory.
+ * Eliminates duplicated boilerplate across bookmarks, watches, history, etc.
+ */
+
+type ArrayStoreOptions<T> = {
+  storageKey: string
+  /** How to extract the unique key from an entry for dedup/lookup */
+  keyOf: (entry: T) => string
+  /** Build a new entry when adding */
+  createEntry: (owner: string, repo: string) => T
+}
+
+type MapStoreOptions = {
+  storageKey: string
+}
+
+/**
+ * Read a JSON value from localStorage with SSR safety and parse error handling.
+ * Returns the parsed value if it passes the guard, otherwise the fallback.
+ */
+function readStorage<T>(key: string, guard: (value: unknown) => value is T, fallback: T): T {
+  if (typeof window === "undefined") {
+    return fallback
+  }
+
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) {
+      return fallback
+    }
+
+    const parsed: unknown = JSON.parse(raw)
+    return guard(parsed) ? parsed : fallback
+  } catch {
+    return fallback
+  }
+}
+
+function writeStorage(key: string, value: unknown): void {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  localStorage.setItem(key, JSON.stringify(value))
+}
+
+// --- Array-based stores (bookmarks, watches, history) ---
+
+function isArray(value: unknown): value is unknown[] {
+  return Array.isArray(value)
+}
+
+/**
+ * Creates an array-backed localStorage store with standard CRUD operations.
+ */
+export function createArrayStore<T extends Record<string, unknown>>(options: ArrayStoreOptions<T>) {
+  const { storageKey, keyOf, createEntry } = options
+
+  function getAll(): T[] {
+    return readStorage<T[]>(storageKey, isArray as (v: unknown) => v is T[], [])
+  }
+
+  function findByFullName(fullName: string): T | undefined {
+    return getAll().find((entry) => keyOf(entry) === fullName)
+  }
+
+  function has(fullName: string): boolean {
+    return getAll().some((entry) => keyOf(entry) === fullName)
+  }
+
+  function add(owner: string, repo: string): T {
+    const items = getAll()
+    const fullName = `${owner}/${repo}`
+    const existing = items.find((entry) => keyOf(entry) === fullName)
+    if (existing) {
+      return existing
+    }
+
+    const entry = createEntry(owner, repo)
+    writeStorage(storageKey, [...items, entry])
+    return entry
+  }
+
+  function remove(fullName: string): void {
+    const items = getAll().filter((entry) => keyOf(entry) !== fullName)
+    writeStorage(storageKey, items)
+  }
+
+  function toggle(owner: string, repo: string): boolean {
+    const fullName = `${owner}/${repo}`
+    if (has(fullName)) {
+      remove(fullName)
+      return false
+    }
+    add(owner, repo)
+    return true
+  }
+
+  return { getAll, findByFullName, has, add, remove, toggle }
+}
+
+// --- Map-based stores (notes, tags) ---
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Creates a map-backed localStorage store keyed by fullName.
+ */
+export function createMapStore<V>(options: MapStoreOptions) {
+  const { storageKey } = options
+
+  function getAll(): Record<string, V> {
+    return readStorage<Record<string, V>>(
+      storageKey,
+      isRecord as (v: unknown) => v is Record<string, V>,
+      {},
+    )
+  }
+
+  function get(key: string): V | undefined {
+    return getAll()[key]
+  }
+
+  function set(key: string, value: V): void {
+    const map = getAll()
+    map[key] = value
+    writeStorage(storageKey, map)
+  }
+
+  function remove(key: string): void {
+    const map = getAll()
+    delete map[key]
+    writeStorage(storageKey, map)
+  }
+
+  function has(key: string): boolean {
+    return key in getAll()
+  }
+
+  return { getAll, get, set, remove, has }
+}

--- a/web/src/lib/notes.ts
+++ b/web/src/lib/notes.ts
@@ -3,52 +3,34 @@
  * Follows the same pattern as tags.ts — keyed by fullName.
  */
 
-const NOTES_STORAGE_KEY = "discofork-notes"
+import { createMapStore } from "./local-storage"
 
 export type NotesMap = Record<string, string>
 
-export function getNotes(): NotesMap {
-  if (typeof window === "undefined") {
-    return {}
-  }
+const store = createMapStore<string>({
+  storageKey: "discofork-notes",
+})
 
-  try {
-    const raw = localStorage.getItem(NOTES_STORAGE_KEY)
-    if (!raw) {
-      return {}
-    }
-
-    const parsed = JSON.parse(raw) as NotesMap
-    return typeof parsed === "object" && parsed !== null ? parsed : {}
-  } catch {
-    return {}
-  }
-}
+export const getNotes = store.getAll
 
 export function getNote(fullName: string): string {
-  const notes = getNotes()
-  return notes[fullName] ?? ""
+  return store.get(fullName) ?? ""
 }
 
 export function setNote(fullName: string, text: string): void {
-  const notes = getNotes()
   if (text.trim()) {
-    notes[fullName] = text
+    store.set(fullName, text)
   } else {
-    delete notes[fullName]
+    store.remove(fullName)
   }
-  localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(notes))
 }
 
 export function removeNote(fullName: string): void {
-  const notes = getNotes()
-  delete notes[fullName]
-  localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(notes))
+  store.remove(fullName)
 }
 
 export function hasNote(fullName: string): boolean {
-  const notes = getNotes()
-  return Boolean(notes[fullName]?.trim())
+  return Boolean(store.get(fullName)?.trim())
 }
 
 export function getAllNotesWithRepos(): Array<{ fullName: string; note: string }> {

--- a/web/src/lib/tags.ts
+++ b/web/src/lib/tags.ts
@@ -1,39 +1,24 @@
-const TAGS_STORAGE_KEY = "discofork-tags"
+import { createMapStore } from "./local-storage"
 
 export type TagsMap = Record<string, string[]>
 
-export function getTags(): TagsMap {
-  if (typeof window === "undefined") {
-    return {}
-  }
+const store = createMapStore<string[]>({
+  storageKey: "discofork-tags",
+})
 
-  try {
-    const raw = localStorage.getItem(TAGS_STORAGE_KEY)
-    if (!raw) {
-      return {}
-    }
-
-    const parsed = JSON.parse(raw) as TagsMap
-    return typeof parsed === "object" && parsed !== null ? parsed : {}
-  } catch {
-    return {}
-  }
-}
+export const getTags = store.getAll
 
 export function getRepoTags(fullName: string): string[] {
-  const tags = getTags()
-  return tags[fullName] ?? []
+  return store.get(fullName) ?? []
 }
 
 export function setRepoTags(fullName: string, repoTags: string[]): void {
-  const tags = getTags()
   const cleaned = [...new Set(repoTags.map((t) => t.trim().toLowerCase()).filter(Boolean))].sort()
   if (cleaned.length === 0) {
-    delete tags[fullName]
+    store.remove(fullName)
   } else {
-    tags[fullName] = cleaned
+    store.set(fullName, cleaned)
   }
-  localStorage.setItem(TAGS_STORAGE_KEY, JSON.stringify(tags))
 }
 
 export function addTag(fullName: string, tag: string): string[] {

--- a/web/src/lib/watches.ts
+++ b/web/src/lib/watches.ts
@@ -1,4 +1,4 @@
-const WATCHES_STORAGE_KEY = "discofork-watches"
+import { createArrayStore } from "./local-storage"
 
 export type WatchEntry = {
   fullName: string
@@ -8,72 +8,34 @@ export type WatchEntry = {
   lastVisitedAt: string
 }
 
-export function getWatches(): WatchEntry[] {
-  if (typeof window === "undefined") {
-    return []
-  }
+const WATCHES_STORAGE_KEY = "discofork-watches"
 
-  try {
-    const raw = localStorage.getItem(WATCHES_STORAGE_KEY)
-    if (!raw) {
-      return []
-    }
-
-    const parsed = JSON.parse(raw) as WatchEntry[]
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-export function isWatched(fullName: string): boolean {
-  return getWatches().some((entry) => entry.fullName === fullName)
-}
-
-export function addWatch(owner: string, repo: string): WatchEntry {
-  const watches = getWatches()
-  const fullName = `${owner}/${repo}`
-
-  const existing = watches.find((entry) => entry.fullName === fullName)
-  if (existing) {
-    return existing
-  }
-
-  const entry: WatchEntry = {
-    fullName,
+const store = createArrayStore<WatchEntry>({
+  storageKey: WATCHES_STORAGE_KEY,
+  keyOf: (entry) => entry.fullName,
+  createEntry: (owner, repo) => ({
+    fullName: `${owner}/${repo}`,
     owner,
     repo,
     watchedAt: new Date().toISOString(),
     lastVisitedAt: new Date().toISOString(),
-  }
+  }),
+})
 
-  localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify([...watches, entry]))
-  return entry
-}
-
-export function removeWatch(fullName: string): void {
-  const watches = getWatches().filter((entry) => entry.fullName !== fullName)
-  localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify(watches))
-}
-
-export function toggleWatch(owner: string, repo: string): boolean {
-  const fullName = `${owner}/${repo}`
-
-  if (isWatched(fullName)) {
-    removeWatch(fullName)
-    return false
-  }
-
-  addWatch(owner, repo)
-  return true
-}
+export const getWatches = store.getAll
+export const isWatched = store.has
+export const addWatch = store.add
+export const removeWatch = store.remove
+export const toggleWatch = store.toggle
 
 export function touchWatch(fullName: string): void {
   const watches = getWatches()
   const entry = watches.find((e) => e.fullName === fullName)
   if (entry) {
     entry.lastVisitedAt = new Date().toISOString()
-    localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify(watches))
+    if (typeof window !== "undefined") {
+      localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify(watches))
+    }
   }
 }
 


### PR DESCRIPTION
Closes #72

## Summary

Extract duplicated SSR-safe localStorage boilerplate into a shared generic utility module (`web/src/lib/local-storage.ts`).

## What changed

- Created `web/src/lib/local-storage.ts` with `createArrayStore<T>` and `createMapStore<V>` factories
- Refactored `bookmarks.ts`, `watches.ts`, `history.ts` to use `createArrayStore`
- Refactored `notes.ts`, `tags.ts` to use `createMapStore`
- All public APIs preserved — no component consumers need changes

## Why this improves Discofork

Eliminates ~100 lines of duplicated boilerplate across 5 files. The SSR detection, safe JSON parsing, and array/object validation pattern was repeated in every localStorage module. Now there is a single source of truth for this pattern, making future changes (e.g., adding error logging, migration logic) a one-file edit instead of a five-file edit.

## Validation

- `npx bun run typecheck` in web/ — passed
- `npx bun run typecheck` in root — passed  
- `npx bun test` — 104 pass, 0 fail

## Risks

- None: all public APIs are preserved identically
- SSR behavior unchanged (returns empty on server)
- `compare.ts` left unchanged due to its URL parameter interleaving
