### PR TITLE
refactor: consolidate suspicious repo validation into shared module

### DIFF
--- a/src/core/suspicious-repo-patterns.ts
+++ b/src/core/suspicious-repo-patterns.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared suspicious repository pattern definitions.
+ *
+ * Both the worker (src/services/github.ts) and the web app
+ * (web/src/lib/repository-route-validation.ts) import these lists
+ * as the single source of truth for known web-probe patterns.
+ *
+ * When adding a new suspicious pattern, edit this file only.
+ */
+
+export const SUSPICIOUS_OWNER_NAMES: readonly string[] = [".well-known"]
+
+/**
+ * Suspicious owner/repo pairs that match known web-probe routes.
+ * Keep these tightly scoped to production-style path probes so
+ * legitimate dotted repo names like github/.github and vercel/next.js
+ * are not flagged.
+ */
+export const SUSPICIOUS_ROUTE_PAIRS: readonly string[] = [
+  "admin/.env",
+  "wp-admin/admin-ajax.php",
+]
+
+const suspiciousOwnerNameSet = new Set<string>(SUSPICIOUS_OWNER_NAMES)
+const suspiciousRoutePairSet = new Set<string>(SUSPICIOUS_ROUTE_PAIRS)
+
+/**
+ * Core suspicious-input validation shared by worker and web layers.
+ * Returns a human-readable reason string when the input is suspicious,
+ * or null when the input passes all checks.
+ *
+ * This function checks: hidden-path prefix, URL-encoded path characters,
+ * path traversal markers, known suspicious owner names, and known
+ * suspicious owner/repo pairs.
+ *
+ * Callers that also need path-separator or SQL-predicate checks should
+ * layer those on top of this function.
+ */
+export function describeSuspiciousRepoInputCore(owner: string, repo: string): string | null {
+  const normalizedOwner = owner.toLowerCase()
+  const normalizedRepo = repo.toLowerCase()
+  const normalizedFullName = `${normalizedOwner}/${normalizedRepo}`
+
+  if (owner.startsWith(".")) {
+    return "Owner segment starts with a hidden-path prefix."
+  }
+
+  if (owner.includes("%") || repo.includes("%")) {
+    return "Owner or repository name still contains URL-encoded path characters."
+  }
+
+  if (owner.includes("..") || repo.includes("..")) {
+    return "Owner or repository name contains path traversal markers."
+  }
+
+  if (suspiciousOwnerNameSet.has(normalizedOwner)) {
+    return "Owner segment matches a known web probe path."
+  }
+
+  if (suspiciousRoutePairSet.has(normalizedFullName)) {
+    return "Owner and repository pair matches a known web probe route."
+  }
+
+  return null
+}

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -6,6 +6,8 @@ import type { Logger } from "../core/logger.ts"
 import { compareForksForSelection, daysSince, recommendForks, scoreForkCandidate } from "./heuristics.ts"
 import { runGitHubCommand } from "./github-command.ts"
 import { runCommand } from "./command.ts"
+import { describeSuspiciousRepoInputCore } from "../core/suspicious-repo-patterns.ts"
+
 
 const repoViewSchema = z.object({
   full_name: z.string(),
@@ -51,8 +53,6 @@ type ForkHeadState = {
 }
 
 type DiscoveryProgressHandler = (message: string) => void
-const suspiciousOwnerNames = new Set([".well-known"])
-const suspiciousRoutePairs = new Set(["admin/.env", "wp-admin/admin-ajax.php"])
 const REPO_HEAD_TIMEOUT_MS = 8000
 const supportedGitHubRepoHosts = new Set(["github.com", "www.github.com"])
 
@@ -138,31 +138,7 @@ export function parseGitHubRepoInput(input: string): GitHubRepoRef {
 
 
 export function describeSuspiciousRepoInput(repo: GitHubRepoRef): string | null {
-  const owner = repo.owner.toLowerCase()
-  const name = repo.name.toLowerCase()
-  const fullName = `${owner}/${name}`
-
-  if (repo.owner.startsWith(".")) {
-    return "Owner segment starts with a hidden-path prefix."
-  }
-
-  if (repo.owner.includes("%") || repo.name.includes("%")) {
-    return "Owner or repository name still contains URL-encoded path characters."
-  }
-
-  if (repo.owner.includes("..") || repo.name.includes("..")) {
-    return "Owner or repository name contains path traversal markers."
-  }
-
-  if (suspiciousOwnerNames.has(owner)) {
-    return "Owner segment matches a known web probe path."
-  }
-
-  if (suspiciousRoutePairs.has(fullName)) {
-    return "Owner and repository pair matches a known web probe route."
-  }
-
-  return null
+  return describeSuspiciousRepoInputCore(repo.owner, repo.name)
 }
 
 async function probeGitHubRepositoryHeadStatus(repo: GitHubRepoRef): Promise<number | null> {

--- a/web/src/lib/repository-route-validation.ts
+++ b/web/src/lib/repository-route-validation.ts
@@ -1,10 +1,8 @@
-const suspiciousOwnerNames = [".well-known"] as const
-// Keep pair-specific denies tightly scoped to production-style path probes so legitimate dotted repo names
-// such as github/.github and vercel/next.js are not treated as invalid lookups.
-const suspiciousRoutePairs = ["admin/.env", "wp-admin/admin-ajax.php"] as const
-
-const suspiciousOwnerNameSet = new Set<string>(suspiciousOwnerNames)
-const suspiciousRoutePairSet = new Set<string>(suspiciousRoutePairs)
+import {
+  SUSPICIOUS_OWNER_NAMES,
+  SUSPICIOUS_ROUTE_PAIRS,
+  describeSuspiciousRepoInputCore,
+} from "../../../src/core/suspicious-repo-patterns"
 
 function quoteSqlLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`
@@ -24,40 +22,19 @@ export const SUSPICIOUS_REPOSITORY_ROUTE_SQL_PREDICATE = [
   "position(chr(92) in repo) > 0",
   "position('..' in owner) > 0",
   "position('..' in repo) > 0",
-  `lower(owner) in (${joinSqlLiterals(suspiciousOwnerNames)})`,
-  `lower(owner || '/' || repo) in (${joinSqlLiterals(suspiciousRoutePairs)})`,
+  `lower(owner) in (${joinSqlLiterals(SUSPICIOUS_OWNER_NAMES)})`,
+  `lower(owner || '/' || repo) in (${joinSqlLiterals(SUSPICIOUS_ROUTE_PAIRS)})`,
 ].join(" or ")
 
 export function describeSuspiciousRepositoryRoute(owner: string, repo: string): string | null {
-  const normalizedOwner = owner.toLowerCase()
-  const normalizedRepo = repo.toLowerCase()
-  const normalizedFullName = `${normalizedOwner}/${normalizedRepo}`
-
-  if (owner.startsWith(".")) {
-    return "Owner segment starts with a hidden-path prefix."
-  }
-
-  if (owner.includes("%") || repo.includes("%")) {
-    return "Owner or repository name still contains URL-encoded path characters."
-  }
-
+  // Path separator check — web-specific because the worker's parseGitHubRepoInput
+  // regex already prevents these from reaching validation.
   if (owner.includes("/") || repo.includes("/") || owner.includes("\\") || repo.includes("\\")) {
     return "Owner or repository name contains path separators."
   }
 
-  if (owner.includes("..") || repo.includes("..")) {
-    return "Owner or repository name contains path traversal markers."
-  }
-
-  if (suspiciousOwnerNameSet.has(normalizedOwner)) {
-    return "Owner segment matches a known web probe path."
-  }
-
-  if (suspiciousRoutePairSet.has(normalizedFullName)) {
-    return "Owner and repository pair matches a known web probe route."
-  }
-
-  return null
+  // Delegate shared checks (hidden prefix, URL-encoded chars, traversal, known patterns)
+  return describeSuspiciousRepoInputCore(owner, repo)
 }
 
 export function isSuspiciousRepositoryRoute(owner: string, repo: string): boolean {


### PR DESCRIPTION
Closes #74

## Summary

Consolidates the duplicated suspicious repository validation logic from `src/services/github.ts` and `web/src/lib/repository-route-validation.ts` into a single shared module at `src/core/suspicious-repo-patterns.ts`.

## What changed

- **New file**: `src/core/suspicious-repo-patterns.ts` — single source of truth for suspicious owner names (`[".well-known"]`), suspicious route pairs (`["admin/.env", "wp-admin/admin-ajax.php"]`), and the core `describeSuspiciousRepoInputCore()` validation function.
- **Modified**: `src/services/github.ts` — removed duplicated `suspiciousOwnerNames`/`suspiciousRoutePairs` sets and inline validation logic; `describeSuspiciousRepoInput()` now delegates to the shared core function.
- **Modified**: `web/src/lib/repository-route-validation.ts` — removed duplicated sets and inline validation logic; `describeSuspiciousRepositoryRoute()` now delegates to the shared core function, keeping its web-specific path-separator check and SQL predicate generation.

## Why this improves Discofork

Previously, both the worker and web app maintained independent copies of the same suspicious pattern lists. Adding a new suspicious pattern required updating both files — if one was missed, the worker and web would have inconsistent security coverage. Now there is exactly one file to edit.

## Validation

- `npx bun run typecheck` — passes
- `npx bun test` — 104/104 tests pass
- Targeted tests: `test/repository-route-validation.test.ts` (3/3 pass), `test/github.test.ts` (8/8 pass)

## Risks

- The web module now imports from `../../../src/core/suspicious-repo-patterns` — a cross-boundary relative path. This works but is worth noting if the project restructures directory layout in the future.
- No behavior change; validation logic is identical to before.