### PR TITLE
feat: add trending repos discovery section to homepage (#76)

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Terminal } from "lucide-react"
 
 import { QueueInput } from "@/components/queue-input"
 import { RepoShell } from "@/components/repo-shell"
+import { TrendingRepos } from "@/components/trending-repos"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -125,6 +126,10 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+
+      <div className="mt-10 sm:mt-14">
+        <TrendingRepos />
+      </div>
     </RepoShell>
   )
 }

--- a/web/src/components/trending-repos.tsx
+++ b/web/src/components/trending-repos.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { GitFork, Star } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import type { RepoListItem, RepoListView } from "@/lib/repository-list"
+
+function formatCount(value: number | null): string {
+  if (value == null) return "0"
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return value.toString()
+}
+
+function RepoCard({ item }: { item: RepoListItem }) {
+  return (
+    <Link
+      href={`/${item.owner}/${item.repo}`}
+      className="group block rounded-[1.25rem] border border-border bg-card/70 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.28)] transition-colors hover:border-primary/40"
+    >
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">
+            {item.fullName}
+          </h3>
+          <div className="flex shrink-0 gap-2">
+            <Badge variant="muted" className="gap-1">
+              <Star className="h-3 w-3" />
+              {formatCount(item.stars)}
+            </Badge>
+            <Badge variant="muted" className="gap-1">
+              <GitFork className="h-3 w-3" />
+              {formatCount(item.forks)}
+            </Badge>
+          </div>
+        </div>
+        {item.upstreamSummary ? (
+          <p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
+            {item.upstreamSummary}
+          </p>
+        ) : null}
+      </div>
+    </Link>
+  )
+}
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-[1.25rem] border border-border bg-card/70 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.28)]">
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+          <div className="flex gap-2">
+            <div className="h-5 w-10 animate-pulse rounded bg-muted" />
+            <div className="h-5 w-10 animate-pulse rounded bg-muted" />
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+          <div className="h-3 w-3/4 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function TrendingRepos() {
+  const [items, setItems] = useState<RepoListItem[] | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        const res = await fetch("/api/repos?order=stars&status=ready&page=1")
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data: RepoListView = await res.json()
+        if (!cancelled) {
+          setItems(data.items.slice(0, 6))
+        }
+      } catch {
+        if (!cancelled) setError(true)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <section className="space-y-5">
+      <div className="space-y-2">
+        <div className="font-mono text-xs uppercase tracking-[0.24em] text-muted-foreground">
+          Trending Repositories
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Top cached repositories by star count.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {error ? (
+          <p className="col-span-full text-sm text-muted-foreground">
+            Could not load trending repositories.
+          </p>
+        ) : items == null
+          ? Array.from({ length: 6 }).map((_, i) => <SkeletonCard key={i} />)
+          : items.map((item) => <RepoCard key={item.fullName} item={item} />)}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Closes #76

## Why

The Discofork homepage currently only shows install instructions and a queue input. Visitors have no way to discover what repositories are already cached — they must already know the exact repo path. This defeats the purpose of a discovery tool.

## What changed

- **New component**: `web/src/components/trending-repos.tsx` — a "use client" component that fetches the top 6 cached repos by star count from `/api/repos?order=stars&status=ready&page=1` and renders them in a responsive card grid.
- **Homepage integration**: Imported and placed `<TrendingRepos />` in `web/src/app/page.tsx` below the existing install/queue sections.
- **Responsive layout**: 1 column on mobile, 2 on sm, 3 on md+.
- **Each card shows**: repo name (linked to `/{owner}/{repo}`), star count, fork count, and truncated upstream summary (line-clamp-2).
- **Loading state**: Skeleton cards display while the API fetch is in flight.
- **Error handling**: Graceful message if the fetch fails.

## Impact

Visitors landing on discofork.ai can now immediately browse top cached repositories without needing to search. This provides a discovery surface that makes the site useful even to first-time visitors who don't know which repos to look up.

## Testing

- `npx bun run typecheck`: pre-existing TS2688 error (bun type definition, same on main)
- `npx bun test`: 72 pass, 13 fail — all failures are pre-existing and identical on main branch baseline. Zero regressions introduced.

## Out of scope / follow-ups

- Pagination or "View all" link for trending repos
- Client-side caching/swr for repeated visits
