### PR TITLE
feat: add freshness indicators on cached repo cards (#84)

### DIFF
--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -19,6 +19,7 @@ import { databaseConfigured } from "@/lib/server/database"
 import { queueConfigured } from "@/lib/server/queue"
 import { listRepoRecords } from "@/lib/server/reports"
 import { cn } from "@/lib/utils"
+import { formatRelativeTime } from "@/lib/utils"
 
 type RepoIndexPageProps = {
   searchParams?: Promise<{
@@ -307,6 +308,15 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
                     </p>
                     <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
                       <span>{statusTimestampLabel(item)}</span>
+                      {item.status === "ready" ? (() => {
+                        const freshness = formatRelativeTime(item.cachedAt)
+                        if (!freshness) return null
+                        return (
+                          <span title={freshness.exactDate}>
+                            <Badge variant={freshness.variant} className="cursor-default">{freshness.label}</Badge>
+                          </span>
+                        )
+                      })() : null}
                       {item.defaultBranch ? <span>{item.defaultBranch}</span> : null}
                       {item.lastPushedAt ? <span>Pushed {formatDate(item.lastPushedAt)}</span> : null}
                     </div>

--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -15,6 +15,7 @@ import { buttonVariants } from "@/components/ui/button"
 import type { CachedRepoView, QueuedRepoView } from "@/lib/repository-service"
 import { exportRepoBrief } from "@/lib/export-brief"
 import { cn } from "@/lib/utils"
+import { formatRelativeTime } from "@/lib/utils"
 import { calculateForkScore, getScoreBadgeVariant } from "@/lib/fork-score"
 import { hasNote } from "@/lib/notes"
 
@@ -353,6 +354,15 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
               <div className="flex flex-wrap items-center gap-3">
                 <Badge variant="success">Cached analysis</Badge>
                 <Badge variant="muted">cached {view.cachedAt}</Badge>
+                {(() => {
+                  const freshness = formatRelativeTime(view.cachedAt)
+                  if (!freshness) return null
+                  return (
+                    <span title={freshness.exactDate}>
+                      <Badge variant={freshness.variant} className="cursor-default">{freshness.label}</Badge>
+                    </span>
+                  )
+                })()}
               </div>
               <div>
                 <h2 className="text-lg font-semibold tracking-tight text-foreground">{view.fullName}</h2>

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -4,3 +4,40 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }
+
+export type FreshnessVariant = "success" | "warning" | "muted"
+
+export function formatRelativeTime(isoDate: string | null): {
+  label: string
+  variant: FreshnessVariant
+  exactDate: string
+} | null {
+  if (!isoDate) return null
+
+  const date = new Date(isoDate)
+  if (Number.isNaN(date.getTime())) return null
+
+  const exactDate = date.toISOString().slice(0, 10)
+  const now = Date.now()
+  const diffMs = now - date.getTime()
+  if (diffMs < 0) return { label: "just now", variant: "success", exactDate }
+
+  const seconds = Math.floor(diffMs / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+  const weeks = Math.floor(days / 7)
+  const months = Math.floor(days / 30)
+
+  let label: string
+  if (seconds < 60) label = "just now"
+  else if (minutes < 60) label = `${minutes}m ago`
+  else if (hours < 24) label = `${hours}h ago`
+  else if (days < 7) label = `${days}d ago`
+  else if (weeks < 5) label = `${weeks}w ago`
+  else label = `${months}mo ago`
+
+  const variant: FreshnessVariant = days < 3 ? "success" : days < 14 ? "warning" : "muted"
+
+  return { label, variant, exactDate }
+}


### PR DESCRIPTION
Closes #84

## Summary

Adds freshness indicators on cached repo cards with relative time labels and colored badges showing how recently repos were cached.

### Changes

- **`web/src/lib/utils.ts`**: Added `formatRelativeTime` helper that converts ISO dates to compact relative labels (`2h ago`, `3d ago`, `2w ago`, `1mo ago`) with a freshness variant:
  - `success` (<3 days): recently cached
  - `warning` (3–14 days): moderately stale
  - `muted` (>14 days): old cache

- **`web/src/app/repos/page.tsx`**: Freshness badge appears next to the cached timestamp on "ready" repo cards in the listing.

- **`web/src/components/repository-brief.tsx`**: Freshness badge appears next to the "cached {date}" badge on the repo brief page.

Exact date is shown on hover via a wrapping `<span title>`.

## Validation

- ✅ `npx bun run typecheck` — root passes
- ✅ `npx bun run typecheck` — web passes
- ✅ `npx bun test` — 104/104 tests pass
