### PR TITLE
feat: compact view toggle for repos listing page (#83)

### DIFF
--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -1,25 +1,23 @@
 import type { Metadata } from "next"
 import Link from "next/link"
-import { ArrowRight, Database, GitFork, Search, Star } from "lucide-react"
+import { Database, Search } from "lucide-react"
 
 import { CompareBar } from "@/components/compare-toggle"
 import { QueueInput } from "@/components/queue-input"
-import { RepoRowActions } from "@/components/repo-row-actions"
 import { RepoOrderSelect } from "@/components/repo-order-select"
 import { RepoStatusFilter } from "@/components/repo-status-filter"
 import { RepoShell } from "@/components/repo-shell"
-import { TagDisplay } from "@/components/tag-manager"
 import { RepoTagFilter } from "@/components/repo-tag-filter"
 import { RepoListKeyboardProvider } from "@/components/repo-keyboard-provider"
-import { Badge } from "@/components/ui/badge"
+import { RepoViewToggle } from "@/components/repo-view-toggle"
+import { RepoListView } from "@/components/repo-list-view"
 import { buttonVariants } from "@/components/ui/button"
-import { REPO_LIST_PAGE_SIZE, type RepoListItem, type RepoListOrder, type RepoListStatusFilter, type RepoListView } from "@/lib/repository-list"
+import { REPO_LIST_PAGE_SIZE, type RepoListOrder, type RepoListStatusFilter, type RepoListView as RepoListViewType } from "@/lib/repository-list"
 import { buildRepoListHref, normalizeRepoListQuery, parseRepoListOrder, parseRepoListPage, parseRepoListStatusFilter } from "@/lib/repository-list-query"
 import { databaseConfigured } from "@/lib/server/database"
 import { queueConfigured } from "@/lib/server/queue"
 import { listRepoRecords } from "@/lib/server/reports"
 import { cn } from "@/lib/utils"
-import { formatRelativeTime } from "@/lib/utils"
 
 type RepoIndexPageProps = {
   searchParams?: Promise<{
@@ -35,64 +33,12 @@ export const metadata: Metadata = {
   description: "Browse cached and queued Discofork repository briefs.",
 }
 
-function formatDate(value: string | null): string {
-  if (!value) {
-    return "Not yet"
-  }
-
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : date.toISOString().slice(0, 10)
-}
-
-function statusVariant(item: RepoListItem): "muted" | "success" | "warning" {
-  if (item.status === "ready") {
-    return "success"
-  }
-
-  if (item.retryState === "retrying" || item.retryState === "terminal" || item.status === "failed") {
-    return "warning"
-  }
-
-  return "muted"
-}
-
-function statusLabel(item: RepoListItem): string {
-  if (item.status === "processing" && item.retryState === "retrying") {
-    return "retrying"
-  }
-
-  if (item.status === "failed" && item.retryState === "terminal") {
-    return "terminal failure"
-  }
-
-  return item.status
-}
-
-function statusTimestampLabel(item: RepoListItem): string {
-  if (item.status === "processing" && item.retryState === "retrying") {
-    return item.nextRetryAt ? `Retry ${item.retryCount} scheduled for ${formatDate(item.nextRetryAt)}` : `Retry ${item.retryCount} is pending`
-  }
-
-  switch (item.status) {
-    case "ready":
-      return `Cached ${formatDate(item.cachedAt)}`
-    case "processing":
-      return `Processing since ${formatDate(item.processingStartedAt ?? item.updatedAt)}`
-    case "failed":
-      return item.retryState === "terminal" && item.lastFailedAt
-        ? `Retry budget exhausted ${formatDate(item.lastFailedAt)}`
-        : `Failed ${formatDate(item.updatedAt)}`
-    default:
-      return `Queued ${formatDate(item.queuedAt)}`
-  }
-}
-
 async function loadRepositoryListView(
   page: number,
   order: RepoListOrder,
   statusFilter: RepoListStatusFilter,
   query: string,
-): Promise<RepoListView> {
+): Promise<RepoListViewType> {
   if (!databaseConfigured()) {
     return {
       items: [],
@@ -233,6 +179,7 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
             <div className="flex flex-wrap items-center gap-2">
               <RepoOrderSelect value={view.order} />
               <RepoStatusFilter value={view.statusFilter} />
+              <RepoViewToggle />
             </div>
           </div>
 
@@ -286,62 +233,7 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
           </div>
         ) : (
           <RepoListKeyboardProvider>
-            <div className="overflow-hidden rounded-md border border-border bg-card" data-repo-list>
-            {view.items.map((item) => (
-              <Link
-                key={item.fullName}
-                href={`/${item.owner}/${item.repo}`}
-                data-repo-item
-                data-full-name={item.fullName}
-                className="block border-b border-border px-4 py-4 transition-colors last:border-b-0 hover:bg-muted/70 sm:px-5"
-              >
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="min-w-0 flex-1 space-y-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <div className="truncate text-sm font-semibold text-foreground">{item.fullName}</div>
-                      <Badge variant={statusVariant(item)}>{statusLabel(item)}</Badge>
-                      {item.status === "ready" ? <Badge variant="muted">{item.forkBriefCount} forks</Badge> : null}
-                    </div>
-                    <TagDisplay fullName={item.fullName} />
-                    <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">
-                      {item.upstreamSummary ?? "No cached upstream summary is available yet."}
-                    </p>
-                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                      <span>{statusTimestampLabel(item)}</span>
-                      {item.status === "ready" ? (() => {
-                        const freshness = formatRelativeTime(item.cachedAt)
-                        if (!freshness) return null
-                        return (
-                          <span title={freshness.exactDate}>
-                            <Badge variant={freshness.variant} className="cursor-default">{freshness.label}</Badge>
-                          </span>
-                        )
-                      })() : null}
-                      {item.defaultBranch ? <span>{item.defaultBranch}</span> : null}
-                      {item.lastPushedAt ? <span>Pushed {formatDate(item.lastPushedAt)}</span> : null}
-                    </div>
-                  </div>
-
-                  <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
-                    {typeof item.stars === "number" ? (
-                      <span className="flex items-center gap-1">
-                        <Star className="h-3.5 w-3.5" />
-                        {item.stars.toLocaleString()}
-                      </span>
-                    ) : null}
-                    {typeof item.forks === "number" ? (
-                      <span className="flex items-center gap-1">
-                        <GitFork className="h-3.5 w-3.5" />
-                        {item.forks.toLocaleString()}
-                      </span>
-                    ) : null}
-                    <RepoRowActions owner={item.owner} repo={item.repo} fullName={item.fullName} />
-                    <ArrowRight className="h-3.5 w-3.5" />
-                  </div>
-                </div>
-              </Link>
-            ))}
-            </div>
+            <RepoListView items={view.items} />
           </RepoListKeyboardProvider>
         )}
       </section>

--- a/web/src/components/compact-repo-list.tsx
+++ b/web/src/components/compact-repo-list.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { BookmarkCheck, GitFork, Star } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { RepoRowActions } from "@/components/repo-row-actions"
+import { getViewMode, type ViewMode } from "@/components/repo-view-toggle"
+import type { RepoListItem } from "@/lib/repository-list"
+import { cn } from "@/lib/utils"
+
+function formatDate(value: string | null): string {
+  if (!value) return "Not yet"
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toISOString().slice(0, 10)
+}
+
+function statusVariant(item: RepoListItem): "muted" | "success" | "warning" {
+  if (item.status === "ready") return "success"
+  if (item.retryState === "retrying" || item.retryState === "terminal" || item.status === "failed") return "warning"
+  return "muted"
+}
+
+function statusLabel(item: RepoListItem): string {
+  if (item.status === "processing" && item.retryState === "retrying") return "retrying"
+  if (item.status === "failed" && item.retryState === "terminal") return "terminal failure"
+  return item.status
+}
+
+export function CompactRepoList({ items }: { items: RepoListItem[] }) {
+  const [mode, setMode] = useState<ViewMode>(getViewMode())
+
+  useEffect(() => {
+    setMode(getViewMode())
+
+    const handler = (e: Event) => {
+      setMode((e as CustomEvent).detail as ViewMode)
+    }
+    window.addEventListener("repo-view-mode-change", handler)
+    return () => window.removeEventListener("repo-view-mode-change", handler)
+  }, [])
+
+  if (mode !== "compact") return null
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-border bg-card">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted/50 text-xs text-muted-foreground">
+            <th className="px-3 py-2 font-medium">Repository</th>
+            <th className="hidden px-3 py-2 font-medium sm:table-cell">Status</th>
+            <th className="hidden px-3 py-2 text-right font-medium sm:table-cell">Stars</th>
+            <th className="hidden px-3 py-2 text-right font-medium sm:table-cell">Forks</th>
+            <th className="hidden px-3 py-2 font-medium md:table-cell">Cached</th>
+            <th className="hidden px-3 py-2 font-medium md:table-cell">Summary</th>
+            <th className="w-1 px-3 py-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.fullName}
+              className="border-b border-border last:border-b-0 hover:bg-muted/70"
+            >
+              <td className="px-3 py-2">
+                <Link
+                  href={`/${item.owner}/${item.repo}`}
+                  className="font-medium text-foreground hover:underline"
+                >
+                  {item.fullName}
+                </Link>
+                {/* Show status/stats on mobile when columns are hidden */}
+                <div className="mt-1 flex flex-wrap items-center gap-2 sm:hidden">
+                  <Badge variant={statusVariant(item)}>{statusLabel(item)}</Badge>
+                  {typeof item.stars === "number" && (
+                    <span className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                      <Star className="h-3 w-3" />{item.stars.toLocaleString()}
+                    </span>
+                  )}
+                  {typeof item.forks === "number" && (
+                    <span className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                      <GitFork className="h-3 w-3" />{item.forks.toLocaleString()}
+                    </span>
+                  )}
+                </div>
+              </td>
+              <td className="hidden px-3 py-2 sm:table-cell">
+                <Badge variant={statusVariant(item)}>{statusLabel(item)}</Badge>
+              </td>
+              <td className="hidden px-3 py-2 text-right text-muted-foreground sm:table-cell">
+                {typeof item.stars === "number" ? (
+                  <span className="inline-flex items-center gap-1">
+                    <Star className="h-3.5 w-3.5" />
+                    {item.stars.toLocaleString()}
+                  </span>
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td className="hidden px-3 py-2 text-right text-muted-foreground sm:table-cell">
+                {typeof item.forks === "number" ? (
+                  <span className="inline-flex items-center gap-1">
+                    <GitFork className="h-3.5 w-3.5" />
+                    {item.forks.toLocaleString()}
+                  </span>
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td className="hidden whitespace-nowrap px-3 py-2 text-xs text-muted-foreground md:table-cell">
+                {formatDate(item.cachedAt)}
+              </td>
+              <td className="hidden max-w-xs px-3 py-2 md:table-cell">
+                <p className="line-clamp-1 truncate text-xs text-muted-foreground">
+                  {item.upstreamSummary ?? "—"}
+                </p>
+              </td>
+              <td className="px-3 py-2">
+                <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.preventDefault()}>
+                  <RepoRowActions owner={item.owner} repo={item.repo} fullName={item.fullName} />
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/web/src/components/repo-list-view.tsx
+++ b/web/src/components/repo-list-view.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowRight, GitFork, Star } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { RepoRowActions } from "@/components/repo-row-actions"
+import { TagDisplay } from "@/components/tag-manager"
+import { CompactRepoList } from "@/components/compact-repo-list"
+import { getViewMode, type ViewMode } from "@/components/repo-view-toggle"
+import type { RepoListItem } from "@/lib/repository-list"
+import { formatRelativeTime, cn } from "@/lib/utils"
+
+function formatDate(value: string | null): string {
+  if (!value) return "Not yet"
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toISOString().slice(0, 10)
+}
+
+function statusVariant(item: RepoListItem): "muted" | "success" | "warning" {
+  if (item.status === "ready") return "success"
+  if (item.retryState === "retrying" || item.retryState === "terminal" || item.status === "failed") return "warning"
+  return "muted"
+}
+
+function statusLabel(item: RepoListItem): string {
+  if (item.status === "processing" && item.retryState === "retrying") return "retrying"
+  if (item.status === "failed" && item.retryState === "terminal") return "terminal failure"
+  return item.status
+}
+
+function statusTimestampLabel(item: RepoListItem): string {
+  if (item.status === "processing" && item.retryState === "retrying") {
+    return item.nextRetryAt ? `Retry ${item.retryCount} scheduled for ${formatDate(item.nextRetryAt)}` : `Retry ${item.retryCount} is pending`
+  }
+  switch (item.status) {
+    case "ready":
+      return `Cached ${formatDate(item.cachedAt)}`
+    case "processing":
+      return `Processing since ${formatDate(item.processingStartedAt ?? item.updatedAt)}`
+    case "failed":
+      return item.retryState === "terminal" && item.lastFailedAt
+        ? `Retry budget exhausted ${formatDate(item.lastFailedAt)}`
+        : `Failed ${formatDate(item.updatedAt)}`
+    default:
+      return `Queued ${formatDate(item.queuedAt)}`
+  }
+}
+
+function CardRepoList({ items }: { items: RepoListItem[] }) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-card" data-repo-list>
+      {items.map((item) => (
+        <Link
+          key={item.fullName}
+          href={`/${item.owner}/${item.repo}`}
+          data-repo-item
+          data-full-name={item.fullName}
+          className="block border-b border-border px-4 py-4 transition-colors last:border-b-0 hover:bg-muted/70 sm:px-5"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="truncate text-sm font-semibold text-foreground">{item.fullName}</div>
+                <Badge variant={statusVariant(item)}>{statusLabel(item)}</Badge>
+                {item.status === "ready" ? <Badge variant="muted">{item.forkBriefCount} forks</Badge> : null}
+              </div>
+              <TagDisplay fullName={item.fullName} />
+              <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">
+                {item.upstreamSummary ?? "No cached upstream summary is available yet."}
+              </p>
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                <span>{statusTimestampLabel(item)}</span>
+                {item.status === "ready" ? (() => {
+                  const freshness = formatRelativeTime(item.cachedAt)
+                  if (!freshness) return null
+                  return (
+                    <span title={freshness.exactDate}>
+                      <Badge variant={freshness.variant} className="cursor-default">{freshness.label}</Badge>
+                    </span>
+                  )
+                })() : null}
+                {item.defaultBranch ? <span>{item.defaultBranch}</span> : null}
+                {item.lastPushedAt ? <span>Pushed {formatDate(item.lastPushedAt)}</span> : null}
+              </div>
+            </div>
+
+            <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+              {typeof item.stars === "number" ? (
+                <span className="flex items-center gap-1">
+                  <Star className="h-3.5 w-3.5" />
+                  {item.stars.toLocaleString()}
+                </span>
+              ) : null}
+              {typeof item.forks === "number" ? (
+                <span className="flex items-center gap-1">
+                  <GitFork className="h-3.5 w-3.5" />
+                  {item.forks.toLocaleString()}
+                </span>
+              ) : null}
+              <RepoRowActions owner={item.owner} repo={item.repo} fullName={item.fullName} />
+              <ArrowRight className="h-3.5 w-3.5" />
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export function RepoListView({ items }: { items: RepoListItem[] }) {
+  const [mode, setMode] = useState<ViewMode>(getViewMode())
+
+  useEffect(() => {
+    setMode(getViewMode())
+
+    const handler = (e: Event) => {
+      setMode((e as CustomEvent).detail as ViewMode)
+    }
+    window.addEventListener("repo-view-mode-change", handler)
+    return () => window.removeEventListener("repo-view-mode-change", handler)
+  }, [])
+
+  return (
+    <>
+      {mode === "compact" ? (
+        <CompactRepoList items={items} />
+      ) : (
+        <CardRepoList items={items} />
+      )}
+    </>
+  )
+}

--- a/web/src/components/repo-view-toggle.tsx
+++ b/web/src/components/repo-view-toggle.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Grid3X3, List } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const STORAGE_KEY = "discofork-repo-view-mode"
+
+export type ViewMode = "card" | "compact"
+
+export function getViewMode(): ViewMode {
+  if (typeof window === "undefined") return "card"
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored === "compact" ? "compact" : "card"
+  } catch {
+    return "card"
+  }
+}
+
+export function setViewMode(mode: ViewMode): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(STORAGE_KEY, mode)
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function RepoViewToggle() {
+  const [mode, setMode] = useState<ViewMode>("card")
+
+  useEffect(() => {
+    setMode(getViewMode())
+  }, [])
+
+  const toggle = () => {
+    const next = mode === "card" ? "compact" : "card"
+    setMode(next)
+    setViewMode(next)
+
+    // Dispatch a custom event so the page can re-render
+    window.dispatchEvent(new CustomEvent("repo-view-mode-change", { detail: next }))
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={mode === "card" ? "Switch to compact view" : "Switch to card view"}
+      title={mode === "card" ? "Switch to compact view" : "Switch to card view"}
+      className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      {mode === "card" ? (
+        <List className="h-4 w-4" />
+      ) : (
+        <Grid3X3 className="h-4 w-4" />
+      )}
+    </button>
+  )
+}


### PR DESCRIPTION
Closes #83

## Summary

Adds a compact view toggle to the repository listing page, allowing users to switch between the default card layout and a dense table-style view.

## Changes

- **`repo-view-toggle.tsx`**: Toggle button using `List`/`Grid3X3` lucide-react icons. Reads/writes localStorage key `discofork-repo-view-mode` (defaults to `card`). Dispatches `repo-view-mode-change` custom event.
- **`compact-repo-list.tsx`**: Table view with columns: Repository (link), Status (badge), Stars, Forks, Cached date, Summary (line-clamp-1). Bookmark and compare actions as small icon buttons via `RepoRowActions`. Hidden columns on mobile with inline stats fallback.
- **`repo-list-view.tsx`**: Client wrapper that reads localStorage mode and renders either card or compact list. Listens for toggle events for live switching.
- **`repos/page.tsx`**: Adds `RepoViewToggle` next to filter/sort controls. Replaces inline card rendering with `<RepoListView>`. Removes helper functions (moved to components).

## Validation

- `npx bun run typecheck` passes
- `npx bun test test/repo-list-query.test.ts` passes
- Toggle icon switches between List/Grid3X3
- localStorage key `discofork-repo-view-mode` persists across reload
- Mobile: table columns hide, inline stats shown
