### PR TITLE
feat: add copy button for install command (#91)

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { ArrowRight, Terminal } from "lucide-react"
 
+import { CopyInstallButton } from "@/components/copy-install-button"
 import { QueueInput } from "@/components/queue-input"
 import { RepoShell } from "@/components/repo-shell"
 import { TrendingRepos } from "@/components/trending-repos"
@@ -24,9 +25,12 @@ export default function HomePage() {
             <div className="space-y-5">
               <Badge variant="success">One command install</Badge>
               <div className="rounded-[1.25rem] border border-border bg-muted/70 p-4 font-mono text-sm text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-                <div className="flex items-center gap-3 text-primary">
-                  <Terminal className="h-4 w-4" />
-                  <span>Installer</span>
+                <div className="flex items-center justify-between gap-3 text-primary">
+                  <div className="flex items-center gap-3">
+                    <Terminal className="h-4 w-4" />
+                    <span>Installer</span>
+                  </div>
+                  <CopyInstallButton command={installCommand} />
                 </div>
                 <div className="mt-3 break-all text-base leading-7">{installCommand}</div>
               </div>

--- a/web/src/components/copy-install-button.tsx
+++ b/web/src/components/copy-install-button.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+
+interface CopyInstallButtonProps {
+  command: string
+}
+
+export function CopyInstallButton({ command }: CopyInstallButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command)
+    } catch {
+      const input = document.createElement("input")
+      input.value = command
+      document.body.appendChild(input)
+      input.select()
+      document.execCommand("copy")
+      document.body.removeChild(input)
+    }
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied to clipboard" : "Copy install command to clipboard"}
+      className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      {copied ? (
+        <Check className="h-4 w-4 text-emerald-500" />
+      ) : (
+        <Copy className="h-4 w-4" />
+      )}
+    </button>
+  )
+}


### PR DESCRIPTION
Adds a copy-to-clipboard button adjacent to the install command on the homepage.

- Copy icon button using 's  icon
- Click copies the install command (Installing Bun...
bun was installed successfully to ~/.bun/bin/bun 

Added "~/.bun/bin" to $PATH in "~/.bash_profile" 

To get started, run: 

  source /home/ec2-user/.bash_profile 
  bun --help 
Downloading Discofork (main)...
Installing runtime dependencies with Bun...
bun install v1.3.12 (700fc117)) to clipboard
- Shows a brief green check + 'Copied!' state that reverts after ~2 seconds
- Accessible: keyboard focusable with 
- Includes fallback for browsers without  support

Closes #91