### PR TITLE
feat: add language filter dropdown to repos page (#93)

### DIFF
--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -5,6 +5,7 @@ import { Database, Search } from "lucide-react"
 import { CompareBar } from "@/components/compare-toggle"
 import { QueueInput } from "@/components/queue-input"
 import { RepoOrderSelect } from "@/components/repo-order-select"
+import { RepoLanguageFilter } from "@/components/repo-language-filter"
 import { RepoStatusFilter } from "@/components/repo-status-filter"
 import { RepoShell } from "@/components/repo-shell"
 import { RepoTagFilter } from "@/components/repo-tag-filter"
@@ -25,6 +26,7 @@ type RepoIndexPageProps = {
     order?: string
     status?: string
     query?: string
+    language?: string
   }>
 }
 
@@ -110,14 +112,31 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
   const order = parseRepoListOrder(resolvedSearchParams?.order)
   const statusFilter = parseRepoListStatusFilter(resolvedSearchParams?.status)
   const query = normalizeRepoListQuery(resolvedSearchParams?.query)
+  const language = resolvedSearchParams?.language?.trim() ?? ""
   const view = await loadRepositoryListView(page, order, statusFilter, query)
+
+  // Client-side language filter on upstreamSummary
+  const filteredItems = language
+    ? view.items.filter((item) => {
+        const summary = (item.upstreamSummary ?? "").toLowerCase()
+        const langLower = language.toLowerCase()
+        // Match exact language name or common aliases
+        const aliases: Record<string, string[]> = {
+          "c++": ["c++", "cpp", "c plus plus"],
+          "c#": ["c#", "csharp", "c sharp"],
+        }
+        const matchTerms = aliases[langLower] ?? [langLower]
+        return matchTerms.some((term) => summary.includes(term))
+      })
+    : view.items
+  const displayView = language ? { ...view, items: filteredItems, total: filteredItems.length } : view
   const previousHref = view.hasPrevious
-    ? buildRepoListHref(view.page - 1, view.order, view.statusFilter, view.query)
-    : buildRepoListHref(1, view.order, view.statusFilter, view.query)
+    ? buildRepoListHref(view.page - 1, view.order, view.statusFilter, view.query, language)
+    : buildRepoListHref(1, view.order, view.statusFilter, view.query, language)
   const nextHref = view.hasNext
-    ? buildRepoListHref(view.page + 1, view.order, view.statusFilter, view.query)
-    : buildRepoListHref(view.page, view.order, view.statusFilter, view.query)
-  const clearSearchHref = buildRepoListHref(1, view.order, view.statusFilter, "")
+    ? buildRepoListHref(view.page + 1, view.order, view.statusFilter, view.query, language)
+    : buildRepoListHref(view.page, view.order, view.statusFilter, view.query, language)
+  const clearSearchHref = buildRepoListHref(1, view.order, view.statusFilter, "", language)
 
   return (
     <RepoShell
@@ -134,7 +153,10 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
             <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
               <div className="flex items-center gap-2">
                 <Database className="h-4 w-4 text-muted-foreground" />
-                <span>{view.total.toLocaleString()} {view.query ? "matching repos" : "repos"}</span>
+                <span>
+                  {view.total.toLocaleString()} {view.query ? "matching repos" : "repos"}
+                  {language ? ` · ${language}` : ""}
+                </span>
               </div>
               <div>Page {view.totalPages === 0 ? 0 : view.page} of {view.totalPages}</div>
               <div>{view.pageSize}/page</div>
@@ -164,6 +186,7 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
               </div>
               <input type="hidden" name="order" value={view.order} />
               <input type="hidden" name="status" value={view.statusFilter} />
+              {language ? <input type="hidden" name="language" value={language} /> : null}
               <div className="flex items-center gap-2">
                 <button type="submit" className={cn(buttonVariants({ variant: "outline" }), "rounded-md px-4")}>
                   Search
@@ -178,6 +201,7 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
 
             <div className="flex flex-wrap items-center gap-2">
               <RepoOrderSelect value={view.order} />
+              <RepoLanguageFilter />
               <RepoStatusFilter value={view.statusFilter} />
               <RepoViewToggle />
             </div>
@@ -213,10 +237,14 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
           <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
             `DATABASE_URL` is not configured for the web backend yet, so the repository index is unavailable.
           </div>
-        ) : view.items.length === 0 ? (
+        ) : displayView.items.length === 0 ? (
           <div className="rounded-md border border-border bg-card p-6 space-y-4">
             <p className="text-sm leading-7 text-muted-foreground">
-              {view.query ? (
+              {language ? (
+                <>
+                  No repositories match the language filter <span className="font-medium text-foreground">"{language}"</span>. Try a different language or clear the filter.
+                </>
+              ) : view.query ? (
                 <>
                   No repositories match <span className="font-medium text-foreground">"{view.query}"</span>. Try a broader owner or repo name, or clear the search.
                 </>
@@ -232,8 +260,8 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
             ) : null}
           </div>
         ) : (
-          <RepoListKeyboardProvider>
-            <RepoListView items={view.items} />
+            <RepoListKeyboardProvider>
+            <RepoListView items={displayView.items} />
           </RepoListKeyboardProvider>
         )}
       </section>

--- a/web/src/components/repo-language-filter.tsx
+++ b/web/src/components/repo-language-filter.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+
+export const REPO_LANGUAGE_OPTIONS = [
+  "Go",
+  "Python",
+  "TypeScript",
+  "JavaScript",
+  "Rust",
+  "Java",
+  "C++",
+  "PHP",
+  "Ruby",
+  "C#",
+  "Swift",
+] as const
+
+export type RepoLanguageOption = (typeof REPO_LANGUAGE_OPTIONS)[number]
+
+export function RepoLanguageFilter() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const currentLanguage = searchParams.get("language") ?? ""
+
+  function handleChange(nextLanguage: string) {
+    const params = new URLSearchParams(searchParams.toString())
+    if (nextLanguage) {
+      params.set("language", nextLanguage)
+    } else {
+      params.delete("language")
+    }
+    params.set("page", "1")
+    router.push(`/repos?${params.toString()}`)
+  }
+
+  return (
+    <label className="flex items-center gap-3 text-sm text-muted-foreground">
+      <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+        Language
+      </span>
+      <select
+        aria-label="Filter repositories by language"
+        value={currentLanguage}
+        onChange={(event) => handleChange(event.target.value)}
+        className="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-ring"
+      >
+        <option value="">All languages</option>
+        {REPO_LANGUAGE_OPTIONS.map((lang) => (
+          <option key={lang} value={lang}>
+            {lang}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}

--- a/web/src/lib/repository-list-query.ts
+++ b/web/src/lib/repository-list-query.ts
@@ -21,7 +21,7 @@ export function normalizeRepoListQuery(rawValue: string | null | undefined): str
   return rawValue?.trim() ?? ""
 }
 
-export function buildRepoListHref(page: number, order: RepoListOrder, statusFilter: RepoListStatusFilter, query: string): string {
+export function buildRepoListHref(page: number, order: RepoListOrder, statusFilter: RepoListStatusFilter, query: string, language = ""): string {
   const params = new URLSearchParams()
 
   if (page > 1) {
@@ -33,6 +33,10 @@ export function buildRepoListHref(page: number, order: RepoListOrder, statusFilt
 
   if (query) {
     params.set("query", query)
+  }
+
+  if (language) {
+    params.set("language", language)
   }
 
   return `/repos?${params.toString()}`


### PR DESCRIPTION
Closes #93

## Summary
Add a programming language filter dropdown to the repository index page. Users can filter cached repos by matching language names against the upstream summary text.

## Changes
- New `RepoLanguageFilter` component with dropdown for 11 common languages (Go, Python, TypeScript, JavaScript, Rust, Java, C++, PHP, Ruby, C#, Swift)
- Server-side filtering on `upstreamSummary` text content with alias support (e.g., C++ matches "cpp", "c plus plus")
- Language parameter persists in URL query params (`?language=Go`) during pagination and search
- Proper empty state message when no repos match the selected language

## Validation
- `npx bun run typecheck` passes
- 4 pre-existing test failures in repos-api-route and repo-api-route (unrelated to this change)
- Language filter dropdown is visible and functional
- URL params persist across pagination
