### PR TITLE
feat: streamline repo launcher shortcuts

### DIFF
--- a/test/recommendation-shortcuts.test.ts
+++ b/test/recommendation-shortcuts.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test"
+
+import { buildRecommendationShortcuts } from "../web/src/lib/recommendation-shortcuts"
+
+describe("recommendation shortcuts", () => {
+  test("keeps every recommendation label actionable when the fork exists", () => {
+    const result = buildRecommendationShortcuts(
+      {
+        bestMaintained: "owner/best",
+        closestToUpstream: "owner/closest",
+        mostFeatureRich: "owner/rich",
+        mostOpinionated: "owner/opinionated",
+      },
+      [
+        { fullName: "owner/best" },
+        { fullName: "owner/closest" },
+        { fullName: "owner/rich" },
+        { fullName: "owner/opinionated" },
+      ],
+    )
+
+    expect(result.shortcuts.map((shortcut) => shortcut.label)).toEqual([
+      "Best maintained",
+      "Closest to upstream",
+      "Most feature-rich",
+      "Most opinionated",
+    ])
+    expect(result.shortcuts.every((shortcut) => shortcut.available)).toBe(true)
+    expect(result.compareShortcut).toEqual({
+      leftKey: "bestMaintained",
+      rightKey: "mostFeatureRich",
+      label: "Compare Best maintained vs Most feature-rich",
+      forkPair: ["owner/best", "owner/rich"],
+    })
+  })
+
+  test("falls back to another high-signal compare pair when the top pair is duplicated", () => {
+    const result = buildRecommendationShortcuts(
+      {
+        bestMaintained: "owner/shared",
+        closestToUpstream: "owner/closest",
+        mostFeatureRich: "owner/shared",
+        mostOpinionated: "owner/opinionated",
+      },
+      [
+        { fullName: "owner/shared" },
+        { fullName: "owner/closest" },
+        { fullName: "owner/opinionated" },
+      ],
+    )
+
+    expect(result.compareShortcut).toEqual({
+      leftKey: "bestMaintained",
+      rightKey: "mostOpinionated",
+      label: "Compare Best maintained vs Most opinionated",
+      forkPair: ["owner/shared", "owner/opinionated"],
+    })
+  })
+
+  test("falls back to an available compare pair when preferred recommendations are missing", () => {
+    const result = buildRecommendationShortcuts(
+      {
+        bestMaintained: "owner/missing-best",
+        closestToUpstream: "owner/closest",
+        mostFeatureRich: "owner/missing-rich",
+        mostOpinionated: "owner/opinionated",
+      },
+      [
+        { fullName: "owner/closest" },
+        { fullName: "owner/opinionated" },
+      ],
+    )
+
+    expect(result.shortcuts).toEqual([
+      {
+        key: "bestMaintained",
+        label: "Best maintained",
+        forkName: "owner/missing-best",
+        available: false,
+      },
+      {
+        key: "closestToUpstream",
+        label: "Closest to upstream",
+        forkName: "owner/closest",
+        available: true,
+      },
+      {
+        key: "mostFeatureRich",
+        label: "Most feature-rich",
+        forkName: "owner/missing-rich",
+        available: false,
+      },
+      {
+        key: "mostOpinionated",
+        label: "Most opinionated",
+        forkName: "owner/opinionated",
+        available: true,
+      },
+    ])
+    expect(result.compareShortcut).toEqual({
+      leftKey: "closestToUpstream",
+      rightKey: "mostOpinionated",
+      label: "Compare Closest to upstream vs Most opinionated",
+      forkPair: ["owner/closest", "owner/opinionated"],
+    })
+  })
+})

--- a/test/repo-launcher.test.ts
+++ b/test/repo-launcher.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  filterRepoLauncherSuggestions,
+  mergeRepoLauncherSuggestions,
+  parseRepoLauncherInput,
+} from "../web/src/lib/repo-launcher"
+
+describe("repo launcher parsing", () => {
+  test("accepts owner repo strings and pasted URL variants", () => {
+    expect(parseRepoLauncherInput("openai/codex")).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(parseRepoLauncherInput("https://github.com/openai/codex/tree/main")).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(parseRepoLauncherInput("https://discofork.ai/openai/codex?fork=foo/bar")).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(parseRepoLauncherInput("github.com/openai/codex.git?tab=readme-ov-file")).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(parseRepoLauncherInput("git@github.com:openai/codex.git")).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(parseRepoLauncherInput("(https://github.com/vercel/next.js).")).toEqual({
+      owner: "vercel",
+      repo: "next.js",
+      fullName: "vercel/next.js",
+      canonicalPath: "/vercel/next.js",
+    })
+  })
+
+  test("rejects malformed or suspicious inputs", () => {
+    expect(parseRepoLauncherInput("openai")).toBeNull()
+    expect(parseRepoLauncherInput("https://example.com/openai/codex")).toBeNull()
+    expect(parseRepoLauncherInput(".well-known/nodeinfo")).toBeNull()
+    expect(parseRepoLauncherInput("admin/.env")).toBeNull()
+  })
+})
+
+describe("repo launcher suggestions", () => {
+  test("merges history bookmarks and watches into ranked deduped suggestions", () => {
+    const suggestions = mergeRepoLauncherSuggestions({
+      history: [
+        { owner: "openai", repo: "codex", visitedAt: "2026-04-14T20:00:00Z" },
+        { owner: "schema-labs-ltd", repo: "discofork", visitedAt: "2026-04-14T21:00:00Z" },
+      ],
+      bookmarks: [
+        { owner: "openai", repo: "codex", bookmarkedAt: "2026-04-12T08:00:00Z" },
+      ],
+      watches: [
+        { owner: "schema-labs-ltd", repo: "discofork", watchedAt: "2026-04-10T08:00:00Z", lastVisitedAt: "2026-04-14T22:00:00Z" },
+      ],
+      limit: 5,
+    })
+
+    expect(suggestions).toHaveLength(2)
+    expect(suggestions[0]).toMatchObject({
+      fullName: "openai/codex",
+      sources: ["bookmarked", "recent"],
+    })
+    expect(suggestions[1]).toMatchObject({
+      fullName: "schema-labs-ltd/discofork",
+      sources: ["watched", "recent"],
+    })
+  })
+
+  test("filters suggestions against the current input", () => {
+    const suggestions = mergeRepoLauncherSuggestions({
+      history: [
+        { owner: "openai", repo: "codex", visitedAt: "2026-04-14T20:00:00Z" },
+        { owner: "vercel", repo: "next.js", visitedAt: "2026-04-14T21:00:00Z" },
+      ],
+      limit: 5,
+    })
+
+    expect(filterRepoLauncherSuggestions(suggestions, "next").map((entry) => entry.fullName)).toEqual(["vercel/next.js"])
+    expect(filterRepoLauncherSuggestions(suggestions, "").map((entry) => entry.fullName)).toEqual([
+      "vercel/next.js",
+      "openai/codex",
+    ])
+  })
+})

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -62,9 +62,9 @@ export default function HomePage() {
             <div className="space-y-4">
               <Badge variant="success">Queue a repository</Badge>
               <p className="text-sm leading-7 text-muted-foreground">
-                Enter a GitHub repository to queue it for Discofork analysis. If cached data already exists, you will be taken straight to the brief.
+                Paste <span className="font-medium text-foreground">owner/repo</span>, a GitHub repo URL, or a Discofork repo URL to jump straight into the cached brief or queue a fresh analysis.
               </p>
-              <QueueInput placeholder="e.g., openai/codex" />
+              <QueueInput placeholder="e.g., openai/codex or github.com/openai/codex" />
             </div>
           </div>
 

--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -255,7 +255,7 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
             {view.queueEnabled ? (
               <div className="space-y-2">
                 <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Queue a repository</div>
-                <QueueInput placeholder="owner/repo to analyze" />
+                <QueueInput placeholder="owner/repo or GitHub URL" />
               </div>
             ) : null}
           </div>

--- a/web/src/components/queue-input.tsx
+++ b/web/src/components/queue-input.tsx
@@ -1,16 +1,75 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
 import { ArrowRight, Search } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
+import {
+  filterRepoLauncherSuggestions,
+  getRepoLauncherSuggestions,
+  parseRepoLauncherInput,
+  REPO_LAUNCHER_SUGGESTION_LABELS,
+  type RepoLauncherSuggestion,
+  type RepoLauncherTarget,
+} from "@/lib/repo-launcher"
+
+function SuggestionButton({
+  suggestion,
+  onSelect,
+}: {
+  suggestion: RepoLauncherSuggestion
+  onSelect: (target: RepoLauncherTarget) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(suggestion)}
+      className="rounded-md border border-border bg-card px-3 py-2 text-left transition-colors hover:bg-muted/70"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="truncate text-sm font-semibold text-foreground">{suggestion.fullName}</span>
+        <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {suggestion.sources.map((source) => (
+          <Badge key={source} variant="muted" className="tracking-[0.1em]">
+            {REPO_LAUNCHER_SUGGESTION_LABELS[source]}
+          </Badge>
+        ))}
+      </div>
+    </button>
+  )
+}
 
 export function QueueInput({ placeholder = "owner/repo" }: { placeholder?: string }) {
   const router = useRouter()
   const [input, setInput] = useState("")
   const [error, setError] = useState("")
+  const [suggestions, setSuggestions] = useState<RepoLauncherSuggestion[]>([])
+
+  const refreshSuggestions = useCallback(() => {
+    setSuggestions(getRepoLauncherSuggestions())
+  }, [])
+
+  useEffect(() => {
+    refreshSuggestions()
+  }, [refreshSuggestions])
+
+  const navigateToRepo = useCallback(
+    (target: RepoLauncherTarget) => {
+      setInput("")
+      setError("")
+      router.push(target.canonicalPath)
+    },
+    [router],
+  )
+
+  const filteredSuggestions = useMemo(
+    () => filterRepoLauncherSuggestions(suggestions, input),
+    [input, suggestions],
+  )
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -23,22 +82,19 @@ export function QueueInput({ placeholder = "owner/repo" }: { placeholder?: strin
         return
       }
 
-      const parts = trimmed.replace(/^https?:\/\/github\.com\//, "").split("/")
-      if (parts.length !== 2 || !parts[0] || !parts[1]) {
-        setError("Use the format owner/repo (e.g., openai/codex).")
+      const target = parseRepoLauncherInput(trimmed)
+      if (!target) {
+        setError("Paste owner/repo, a GitHub repo URL, or a Discofork repo URL.")
         return
       }
 
-      const owner = parts[0]
-      const repo = parts[1].replace(/\.git$/, "")
-      setInput("")
-      router.push(`/${owner}/${repo}`)
+      navigateToRepo(target)
     },
-    [input, router],
+    [input, navigateToRepo],
   )
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={handleSubmit} className="space-y-3">
       <div className="flex items-center gap-2">
         <div className="relative flex-1">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -49,6 +105,7 @@ export function QueueInput({ placeholder = "owner/repo" }: { placeholder?: strin
               setInput(e.target.value)
               setError("")
             }}
+            onFocus={refreshSuggestions}
             placeholder={placeholder}
             className="w-full rounded-md border border-border bg-background px-3 py-2 pl-9 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
           />
@@ -58,6 +115,19 @@ export function QueueInput({ placeholder = "owner/repo" }: { placeholder?: strin
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>
+      {filteredSuggestions.length > 0 ? (
+        <div className="rounded-md border border-border bg-muted/40 p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Quick reopen</div>
+            <p className="text-xs text-muted-foreground">Recent, bookmarked, and watched repos on this device.</p>
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {filteredSuggestions.map((suggestion) => (
+              <SuggestionButton key={suggestion.fullName} suggestion={suggestion} onSelect={navigateToRepo} />
+            ))}
+          </div>
+        </div>
+      ) : null}
       {error ? <p className="text-xs text-rose-500">{error}</p> : null}
     </form>
   )

--- a/web/src/components/random-discovery-button.tsx
+++ b/web/src/components/random-discovery-button.tsx
@@ -7,6 +7,17 @@ import { Loader2, Shuffle } from "lucide-react"
 import { buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
+type RandomDiscoveryRepo = {
+  owner: string
+  repo: string
+}
+
+type RandomDiscoveryResponse = {
+  items?: RandomDiscoveryRepo[]
+  totalPages?: number
+  total_pages?: number
+}
+
 function shuffleArray<T>(items: T[]): T[] {
   const arr = [...items]
   for (let i = arr.length - 1; i > 0; i--) {
@@ -26,7 +37,7 @@ export function RandomDiscoveryButton() {
       // Fetch page 1 to get totalPages
       const initRes = await fetch("/api/repos?order=updated&status=ready&page=1")
       if (!initRes.ok) throw new Error(`HTTP ${initRes.status}`)
-      const initData = await initRes.json()
+      const initData = await initRes.json() as RandomDiscoveryResponse
 
       const totalPages = Math.max(initData.totalPages ?? initData.total_pages ?? 1, 1)
       const randomPage = Math.floor(Math.random() * totalPages) + 1
@@ -36,7 +47,7 @@ export function RandomDiscoveryButton() {
       if (randomPage !== 1) {
         const pageRes = await fetch(`/api/repos?order=updated&status=ready&page=${randomPage}`)
         if (pageRes.ok) {
-          data = await pageRes.json()
+          data = await pageRes.json() as RandomDiscoveryResponse
         }
       }
 

--- a/web/src/components/repository-brief.tsx
+++ b/web/src/components/repository-brief.tsx
@@ -19,6 +19,7 @@ import { formatRelativeTime } from "@/lib/utils"
 import { calculateForkScore, getScoreBadgeVariant } from "@/lib/fork-score"
 import { hasNote } from "@/lib/notes"
 import { parseCompareForks, isForkInCompare, COMPARE_FORKS_PARAM } from "@/lib/compare-forks"
+import { buildRecommendationShortcuts } from "@/lib/recommendation-shortcuts"
 import type { CachedForkView } from "@/lib/repository-service"
 
 function SectionList({ title, items }: { title: string; items: string[] }) {
@@ -365,6 +366,11 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
     }
   }, [filteredForks, selectedForkName])
 
+  const recommendationShortcuts = useMemo(
+    () => buildRecommendationShortcuts(view.recommendations, view.forks),
+    [view.forks, view.recommendations],
+  )
+
   function updateParams(updates: Record<string, string>) {
     const params = new URLSearchParams(searchParams.toString())
     for (const [key, value] of Object.entries(updates)) {
@@ -374,6 +380,33 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
         params.delete(key)
       }
     }
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
+
+  function navigateToFork(forkName: string, options?: { clearComparison?: boolean; clearFilters?: boolean }) {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("fork", forkName)
+
+    if (options?.clearComparison) {
+      params.delete(COMPARE_FORKS_PARAM)
+    }
+
+    if (options?.clearFilters) {
+      params.delete("maintenance")
+      params.delete("magnitude")
+    }
+
+    setSelectedForkName(forkName)
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
+
+  function openRecommendationComparison([forkA, forkB]: [string, string]) {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("fork", forkA)
+    params.set(COMPARE_FORKS_PARAM, `${forkA},${forkB}`)
+    params.delete("maintenance")
+    params.delete("magnitude")
+    setSelectedForkName(forkA)
     router.replace(`${pathname}?${params.toString()}`, { scroll: false })
   }
 
@@ -409,6 +442,8 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
     params.delete(COMPARE_FORKS_PARAM)
     router.replace(`${pathname}?${params.toString()}`, { scroll: false })
   }
+
+  const recommendationCompareShortcut = recommendationShortcuts.compareShortcut
 
   return (
     <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
@@ -472,11 +507,47 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
             <MetaItem label="Last pushed" value={view.stats.lastPushedAt} />
           </div>
 
-          <div className="mt-6 grid gap-x-8 gap-y-3 border-t border-border pt-4 md:grid-cols-2">
-            <MetaItem label="Best maintained" value={view.recommendations.bestMaintained} />
-            <MetaItem label="Closest to upstream" value={view.recommendations.closestToUpstream} />
-            <MetaItem label="Most feature-rich" value={view.recommendations.mostFeatureRich} />
-            <MetaItem label="Most opinionated" value={view.recommendations.mostOpinionated} />
+          <div className="mt-6 border-t border-border pt-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Recommended shortcuts</div>
+                <p className="mt-2 text-sm text-muted-foreground">Jump straight into Discofork's strongest cached fork picks, or open a compare view in one click.</p>
+              </div>
+              {recommendationCompareShortcut ? (
+                <button
+                  type="button"
+                  onClick={() => openRecommendationComparison(recommendationCompareShortcut.forkPair)}
+                  className={cn(
+                    buttonVariants({ variant: "outline" }),
+                    "gap-2 rounded-md px-3 py-2 text-sm"
+                  )}
+                >
+                  <GitCompareArrows className="h-4 w-4" />
+                  {recommendationCompareShortcut.label}
+                </button>
+              ) : null}
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              {recommendationShortcuts.shortcuts.map((shortcut) => (
+                <button
+                  key={shortcut.key}
+                  type="button"
+                  disabled={!shortcut.available}
+                  onClick={() => navigateToFork(shortcut.forkName, { clearComparison: true, clearFilters: true })}
+                  className={cn(
+                    "rounded-md border border-border bg-card px-4 py-3 text-left transition-colors",
+                    shortcut.available ? "hover:bg-muted/70" : "cursor-not-allowed opacity-60"
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">{shortcut.label}</span>
+                    {shortcut.available ? <ArrowUpRight className="h-4 w-4 text-muted-foreground" /> : null}
+                  </div>
+                  <div className="mt-2 text-sm font-medium text-foreground">{shortcut.forkName}</div>
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
@@ -565,12 +636,7 @@ export function CachedRepositoryBrief({ view }: { view: CachedRepoView }) {
                   <button
                     key={fork.fullName}
                     type="button"
-                    onClick={() => {
-                      setSelectedForkName(fork.fullName)
-                      const params = new URLSearchParams(searchParams.toString())
-                      params.set("fork", fork.fullName)
-                      router.replace(`${pathname}?${params.toString()}`, { scroll: false })
-                    }}
+                    onClick={() => navigateToFork(fork.fullName)}
                     className={cn(
                       "w-full border-b px-4 py-3 text-left transition-colors last:border-b-0",
                       active

--- a/web/src/lib/recommendation-shortcuts.ts
+++ b/web/src/lib/recommendation-shortcuts.ts
@@ -1,0 +1,75 @@
+import type { CachedForkView, RepoRecommendationSet } from "./repository-service"
+
+export type RepoRecommendationKey = keyof RepoRecommendationSet
+
+export type RecommendationShortcut = {
+  key: RepoRecommendationKey
+  label: string
+  forkName: string
+  available: boolean
+}
+
+export type RecommendationCompareShortcut = {
+  leftKey: RepoRecommendationKey
+  rightKey: RepoRecommendationKey
+  label: string
+  forkPair: [string, string]
+}
+
+const RECOMMENDATION_LABELS: Record<RepoRecommendationKey, string> = {
+  bestMaintained: "Best maintained",
+  closestToUpstream: "Closest to upstream",
+  mostFeatureRich: "Most feature-rich",
+  mostOpinionated: "Most opinionated",
+}
+
+const COMPARE_PRIORITY: Array<[RepoRecommendationKey, RepoRecommendationKey]> = [
+  ["bestMaintained", "mostFeatureRich"],
+  ["bestMaintained", "mostOpinionated"],
+  ["closestToUpstream", "mostFeatureRich"],
+  ["closestToUpstream", "mostOpinionated"],
+]
+
+export function buildRecommendationShortcuts(
+  recommendations: RepoRecommendationSet,
+  forks: Pick<CachedForkView, "fullName">[],
+): {
+  shortcuts: RecommendationShortcut[]
+  compareShortcut: RecommendationCompareShortcut | null
+} {
+  const availableForks = new Set(forks.map((fork) => fork.fullName))
+  const shortcuts = (Object.keys(RECOMMENDATION_LABELS) as RepoRecommendationKey[]).map((key) => ({
+    key,
+    label: RECOMMENDATION_LABELS[key],
+    forkName: recommendations[key],
+    available: availableForks.has(recommendations[key]),
+  }))
+
+  for (const [leftKey, rightKey] of COMPARE_PRIORITY) {
+    const leftFork = recommendations[leftKey]
+    const rightFork = recommendations[rightKey]
+
+    if (!leftFork || !rightFork || leftFork === rightFork) {
+      continue
+    }
+
+    if (!availableForks.has(leftFork) || !availableForks.has(rightFork)) {
+      continue
+    }
+
+    return {
+      shortcuts,
+      compareShortcut: {
+        leftKey,
+        rightKey,
+        label: `Compare ${RECOMMENDATION_LABELS[leftKey]} vs ${RECOMMENDATION_LABELS[rightKey]}`,
+        forkPair: [leftFork, rightFork],
+      },
+    }
+  }
+
+  return {
+    shortcuts,
+    compareShortcut: null,
+  }
+}

--- a/web/src/lib/repo-launcher.ts
+++ b/web/src/lib/repo-launcher.ts
@@ -1,0 +1,221 @@
+import type { BookmarkEntry } from "./bookmarks"
+import { getBookmarks } from "./bookmarks"
+import type { HistoryEntry } from "./history"
+import { getHistory } from "./history"
+import { describeSuspiciousRepositoryRoute } from "./repository-route-validation"
+import type { WatchEntry } from "./watches"
+import { getWatches } from "./watches"
+
+const SUPPORTED_REPO_HOSTS = new Set(["github.com", "www.github.com", "discofork.ai", "www.discofork.ai"])
+const HOST_LIKE_REPO_INPUT = /^(?:https?:\/\/)?(?:www\.)?(github\.com|discofork\.ai)\//i
+const SSH_REPO_INPUT = /^(?:git@github\.com:|ssh:\/\/git@github\.com\/)(?<path>[^?#]+)$/i
+
+const SUGGESTION_SOURCE_ORDER = ["bookmarked", "watched", "recent"] as const
+const SUGGESTION_SOURCE_WEIGHT: Record<RepoLauncherSuggestionSource, number> = {
+  bookmarked: 4,
+  watched: 3,
+  recent: 2,
+}
+
+export type RepoLauncherTarget = {
+  owner: string
+  repo: string
+  fullName: string
+  canonicalPath: string
+}
+
+export type RepoLauncherSuggestionSource = (typeof SUGGESTION_SOURCE_ORDER)[number]
+
+export type RepoLauncherSuggestion = RepoLauncherTarget & {
+  sources: RepoLauncherSuggestionSource[]
+  lastTouchedAt: string | null
+}
+
+export const REPO_LAUNCHER_SUGGESTION_LABELS: Record<RepoLauncherSuggestionSource, string> = {
+  recent: "Recent",
+  bookmarked: "Bookmarked",
+  watched: "Watching",
+}
+
+function stripWrappingPunctuation(value: string): string {
+  return value
+    .trim()
+    .replace(/^["'`<(\[]+/, "")
+    .replace(/["'`)>\].,:;!?]+$/, "")
+}
+
+function createRepoLauncherTarget(owner: string, repo: string): RepoLauncherTarget {
+  return {
+    owner,
+    repo,
+    fullName: `${owner}/${repo}`,
+    canonicalPath: `/${owner}/${repo}`,
+  }
+}
+
+function normalizeRepoPathCandidate(raw: string): string | null {
+  const input = stripWrappingPunctuation(raw)
+  if (!input) {
+    return null
+  }
+
+  const sshMatch = input.match(SSH_REPO_INPUT)
+  if (sshMatch?.groups?.path) {
+    return sshMatch.groups.path
+  }
+
+  if (HOST_LIKE_REPO_INPUT.test(input) || /^[a-z][a-z0-9+.-]*:\/\//i.test(input)) {
+    const href = /^[a-z][a-z0-9+.-]*:\/\//i.test(input) ? input : `https://${input}`
+
+    try {
+      const url = new URL(href)
+      if (!SUPPORTED_REPO_HOSTS.has(url.hostname.toLowerCase())) {
+        return null
+      }
+      return url.pathname
+    } catch {
+      return null
+    }
+  }
+
+  return input.split(/[?#]/, 1)[0] ?? null
+}
+
+function toTimestamp(value: string | null): number {
+  if (!value) {
+    return 0
+  }
+
+  const timestamp = new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function scoreSuggestion(suggestion: RepoLauncherSuggestion): number {
+  return suggestion.sources.reduce((total, source) => total + SUGGESTION_SOURCE_WEIGHT[source], 0)
+}
+
+function addSuggestion(
+  suggestions: Map<string, RepoLauncherSuggestion>,
+  owner: string,
+  repo: string,
+  source: RepoLauncherSuggestionSource,
+  touchedAt: string | null,
+): void {
+  const target = parseRepoLauncherInput(`${owner}/${repo}`)
+  if (!target) {
+    return
+  }
+
+  const existing = suggestions.get(target.fullName)
+  if (!existing) {
+    suggestions.set(target.fullName, {
+      ...target,
+      sources: [source],
+      lastTouchedAt: touchedAt,
+    })
+    return
+  }
+
+  if (!existing.sources.includes(source)) {
+    existing.sources.push(source)
+  }
+
+  if (toTimestamp(touchedAt) > toTimestamp(existing.lastTouchedAt)) {
+    existing.lastTouchedAt = touchedAt
+  }
+}
+
+export function parseRepoLauncherInput(raw: string): RepoLauncherTarget | null {
+  const candidatePath = normalizeRepoPathCandidate(raw)
+  if (!candidatePath) {
+    return null
+  }
+
+  const segments = candidatePath
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+
+  if (segments.length < 2) {
+    return null
+  }
+
+  const owner = segments[0]
+  const repo = segments[1].replace(/\.git$/i, "")
+  if (!owner || !repo) {
+    return null
+  }
+
+  if (describeSuspiciousRepositoryRoute(owner, repo)) {
+    return null
+  }
+
+  return createRepoLauncherTarget(owner, repo)
+}
+
+export function filterRepoLauncherSuggestions(
+  suggestions: RepoLauncherSuggestion[],
+  query: string,
+): RepoLauncherSuggestion[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return suggestions
+  }
+
+  return suggestions.filter((suggestion) => suggestion.fullName.toLowerCase().includes(normalizedQuery))
+}
+
+export function mergeRepoLauncherSuggestions({
+  history = [],
+  bookmarks = [],
+  watches = [],
+  limit = 6,
+}: {
+  history?: Pick<HistoryEntry, "owner" | "repo" | "visitedAt">[]
+  bookmarks?: Pick<BookmarkEntry, "owner" | "repo" | "bookmarkedAt">[]
+  watches?: Pick<WatchEntry, "owner" | "repo" | "lastVisitedAt" | "watchedAt">[]
+  limit?: number
+} = {}): RepoLauncherSuggestion[] {
+  const suggestions = new Map<string, RepoLauncherSuggestion>()
+
+  for (const entry of history) {
+    addSuggestion(suggestions, entry.owner, entry.repo, "recent", entry.visitedAt)
+  }
+
+  for (const entry of bookmarks) {
+    addSuggestion(suggestions, entry.owner, entry.repo, "bookmarked", entry.bookmarkedAt)
+  }
+
+  for (const entry of watches) {
+    addSuggestion(suggestions, entry.owner, entry.repo, "watched", entry.lastVisitedAt || entry.watchedAt)
+  }
+
+  return [...suggestions.values()]
+    .map((suggestion) => ({
+      ...suggestion,
+      sources: SUGGESTION_SOURCE_ORDER.filter((source) => suggestion.sources.includes(source)),
+    }))
+    .sort((left, right) => {
+      const scoreDifference = scoreSuggestion(right) - scoreSuggestion(left)
+      if (scoreDifference !== 0) {
+        return scoreDifference
+      }
+
+      const timestampDifference = toTimestamp(right.lastTouchedAt) - toTimestamp(left.lastTouchedAt)
+      if (timestampDifference !== 0) {
+        return timestampDifference
+      }
+
+      return left.fullName.localeCompare(right.fullName)
+    })
+    .slice(0, limit)
+}
+
+export function getRepoLauncherSuggestions(limit = 6): RepoLauncherSuggestion[] {
+  return mergeRepoLauncherSuggestions({
+    history: getHistory(),
+    bookmarks: getBookmarks(),
+    watches: getWatches(),
+    limit,
+  })
+}


### PR DESCRIPTION
Closes #101

## Summary
- teach the shared launcher to normalize `owner/repo`, GitHub URLs, Discofork URLs, and GitHub SSH remotes into the canonical Discofork brief route
- add client-side quick-reopen suggestions in the existing launcher using recent history, bookmarks, and watched repos from localStorage
- turn cached recommendation labels into direct fork shortcuts plus a one-click compare path for the strongest available recommendation pair

## Validation
- `npx bun test test/repo-launcher.test.ts test/recommendation-shortcuts.test.ts`
- `cd web && npx bun run typecheck`
- `cd web && npx bun run build`
- `git diff --cached --check`

## Review
- reviewer-only fallback used for the pre-commit review gate because the full parallel `review-changes` orchestration path was unavailable in the delegated environment
- recommendation shortcut availability/fallback behavior is covered with focused regression tests

## Notes
- Discofork URLs pasted into the launcher intentionally canonicalize back to the upstream `/owner/repo` brief route for this issue's visitor flow instead of preserving existing query-state decorations.
