### PR TITLE
fix: restore web suspicious repo validation build safety

### DIFF
--- a/test/repository-route-validation.test.ts
+++ b/test/repository-route-validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
 
 import {
   SUSPICIOUS_REPOSITORY_ROUTE_SQL_PREDICATE,
@@ -22,6 +23,13 @@ describe("repository route validation", () => {
     expect(describeSuspiciousRepositoryRoute("github", ".github")).toBeNull()
     expect(describeSuspiciousRepositoryRoute("vercel", "next.js")).toBeNull()
     expect(isSuspiciousRepositoryRoute("schema-labs-ltd", "discofork")).toBe(false)
+  })
+
+  test("uses the web-local suspicious pattern module alias", () => {
+    const source = readFileSync(new URL("../web/src/lib/repository-route-validation.ts", import.meta.url), "utf8")
+
+    expect(source).toContain('from "@/core/suspicious-repo-patterns"')
+    expect(source).not.toContain('from "../../../src/core/suspicious-repo-patterns"')
   })
 
   test("exports a SQL predicate for filtering suspicious stored rows", () => {

--- a/test/web-suspicious-repo-patterns.test.ts
+++ b/test/web-suspicious-repo-patterns.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  SUSPICIOUS_OWNER_NAMES,
+  SUSPICIOUS_ROUTE_PAIRS,
+  describeSuspiciousRepoInputCore,
+} from "../web/src/core/suspicious-repo-patterns"
+
+describe("web suspicious repo patterns", () => {
+  test("shares the known suspicious owner and route patterns needed by the web bundle", () => {
+    expect(SUSPICIOUS_OWNER_NAMES).toContain(".well-known")
+    expect(SUSPICIOUS_ROUTE_PAIRS).toContain("admin/.env")
+    expect(SUSPICIOUS_ROUTE_PAIRS).toContain("wp-admin/admin-ajax.php")
+  })
+
+  test("keeps suspicious routes blocked while allowing legitimate dotted repos", () => {
+    expect(describeSuspiciousRepoInputCore(".well-known", "nodeinfo")).toContain("hidden-path prefix")
+    expect(describeSuspiciousRepoInputCore("admin", ".env")).toContain("known web probe route")
+    expect(describeSuspiciousRepoInputCore("github", ".github")).toBeNull()
+    expect(describeSuspiciousRepoInputCore("vercel", "next.js")).toBeNull()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     "jsxImportSource": "@opentui/react",
     "allowJs": false,
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["web/src/*"]
+    },
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,

--- a/web/src/core/suspicious-repo-patterns.ts
+++ b/web/src/core/suspicious-repo-patterns.ts
@@ -1,0 +1,58 @@
+/**
+ * Web-local suspicious repository pattern definitions.
+ *
+ * Railway builds the web service from the `web/` directory, so any module
+ * imported into the Next.js bundle must stay inside `web/src`.
+ *
+ * Keep this file aligned with `src/core/suspicious-repo-patterns.ts` when the
+ * worker-side validation rules change.
+ */
+
+export const SUSPICIOUS_OWNER_NAMES: readonly string[] = [".well-known"]
+
+/**
+ * Suspicious owner/repo pairs that match known web-probe routes.
+ * Keep these tightly scoped to production-style path probes so
+ * legitimate dotted repo names like github/.github and vercel/next.js
+ * are not flagged.
+ */
+export const SUSPICIOUS_ROUTE_PAIRS: readonly string[] = [
+  "admin/.env",
+  "wp-admin/admin-ajax.php",
+]
+
+const suspiciousOwnerNameSet = new Set<string>(SUSPICIOUS_OWNER_NAMES)
+const suspiciousRoutePairSet = new Set<string>(SUSPICIOUS_ROUTE_PAIRS)
+
+/**
+ * Core suspicious-input validation shared by the web route validation and
+ * repo launcher logic. Returns a human-readable reason string when the input
+ * is suspicious, or null when the input passes all checks.
+ */
+export function describeSuspiciousRepoInputCore(owner: string, repo: string): string | null {
+  const normalizedOwner = owner.toLowerCase()
+  const normalizedRepo = repo.toLowerCase()
+  const normalizedFullName = `${normalizedOwner}/${normalizedRepo}`
+
+  if (owner.startsWith(".")) {
+    return "Owner segment starts with a hidden-path prefix."
+  }
+
+  if (owner.includes("%") || repo.includes("%")) {
+    return "Owner or repository name still contains URL-encoded path characters."
+  }
+
+  if (owner.includes("..") || repo.includes("..")) {
+    return "Owner or repository name contains path traversal markers."
+  }
+
+  if (suspiciousOwnerNameSet.has(normalizedOwner)) {
+    return "Owner segment matches a known web probe path."
+  }
+
+  if (suspiciousRoutePairSet.has(normalizedFullName)) {
+    return "Owner and repository pair matches a known web probe route."
+  }
+
+  return null
+}

--- a/web/src/lib/repository-route-validation.ts
+++ b/web/src/lib/repository-route-validation.ts
@@ -2,7 +2,7 @@ import {
   SUSPICIOUS_OWNER_NAMES,
   SUSPICIOUS_ROUTE_PAIRS,
   describeSuspiciousRepoInputCore,
-} from "../../../src/core/suspicious-repo-patterns"
+} from "@/core/suspicious-repo-patterns"
 
 function quoteSqlLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`


### PR DESCRIPTION
Closes #103

## Summary
- copy the suspicious repo pattern helper into `web/src/core/` so the Next.js bundle no longer imports outside the Railway `/web` build context
- switch `web/src/lib/repository-route-validation.ts` to the `@/core/suspicious-repo-patterns` alias and mirror that alias in the root `tsconfig.json` for Bun-based root verification
- add regression coverage for the web-local helper behavior and a deterministic source assertion that would have caught the broken `../../../src/core/...` import path

## Reproduction
- `cd web && npm run build` passed inside the full repository because the parent `src/` tree still existed locally
- copying `web/` into an isolated Railway-style build directory reproduced the production failure before the fix: `Module not found: Can't resolve '../../../src/core/suspicious-repo-patterns'`
- the same isolated build now succeeds after the fix

## Validation
- `npx bun test test/repository-route-validation.test.ts test/web-suspicious-repo-patterns.test.ts` ❌ before the fix
- `npx bun test test/repository-route-validation.test.ts test/repo-launcher.test.ts test/web-suspicious-repo-patterns.test.ts` ✅ after the fix
- `npx bun test` ✅
- `cd web && npx bun run typecheck` ✅
- `cd web && npm run build` ✅
- isolated Railway-style `web` copy: `npm run build` ✅ after the fix
- `git diff --check` ✅
- `npx bun run typecheck` at repo root still reports pre-existing unrelated errors in untouched web storage helpers / `repo-launcher.ts`; the new `@/core` resolution error introduced by this fix path was removed by the root `tsconfig.json` alias mapping

## Review gate
Full `review-changes` orchestration was unavailable in this delegated environment, so I used the documented reviewer-only fallback: canonical local diff review plus `git diff --check`. No blocking or important findings remained after the validation pass.
