### PR TITLE
feat(web): upgrade quick jump launcher

### DIFF
--- a/test/quick-jump-dialog.test.ts
+++ b/test/quick-jump-dialog.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  getDefaultQuickJumpSuggestionIndex,
+  getNextQuickJumpSuggestionIndex,
+  resolveQuickJumpTarget,
+} from "../web/src/lib/quick-jump"
+import { filterRepoLauncherSuggestions, mergeRepoLauncherSuggestions } from "../web/src/lib/repo-launcher"
+
+const suggestions = mergeRepoLauncherSuggestions({
+  history: [
+    { owner: "openai", repo: "codex", visitedAt: "2026-04-14T20:00:00Z" },
+    { owner: "vercel", repo: "next.js", visitedAt: "2026-04-14T21:00:00Z" },
+  ],
+  bookmarks: [{ owner: "openai", repo: "codex", bookmarkedAt: "2026-04-12T08:00:00Z" }],
+  watches: [{ owner: "schema-labs-ltd", repo: "discofork", watchedAt: "2026-04-10T08:00:00Z", lastVisitedAt: "2026-04-14T22:00:00Z" }],
+  limit: 6,
+})
+
+describe("quick jump launcher helpers", () => {
+  test("reuses repo-launcher parsing for direct submissions", () => {
+    expect(resolveQuickJumpTarget("openai/codex", suggestions, 0)).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(resolveQuickJumpTarget("https://github.com/openai/codex/tree/main", suggestions, 0)).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(resolveQuickJumpTarget("https://discofork.ai/openai/codex?fork=schema-labs-ltd/discofork", suggestions, 0)).toEqual({
+      owner: "openai",
+      repo: "codex",
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(resolveQuickJumpTarget("https://discofork.ai/.well-known/nodeinfo", suggestions, -1)).toBeNull()
+  })
+
+  test("lets an explicit suggestion selection override a valid parsed target", () => {
+    expect(resolveQuickJumpTarget("openai/codex", suggestions, 1)).toMatchObject({
+      fullName: "openai/codex",
+      canonicalPath: "/openai/codex",
+    })
+
+    expect(resolveQuickJumpTarget("openai/codex", suggestions, 1, { preferActiveSuggestion: true })).toMatchObject({
+      fullName: "schema-labs-ltd/discofork",
+      canonicalPath: "/schema-labs-ltd/discofork",
+    })
+  })
+
+  test("falls back to the active quick-reopen suggestion for filter-only input", () => {
+    const filteredSuggestions = filterRepoLauncherSuggestions(suggestions, "next")
+
+    expect(resolveQuickJumpTarget("next", filteredSuggestions, 0)).toMatchObject({
+      fullName: "vercel/next.js",
+      canonicalPath: "/vercel/next.js",
+    })
+  })
+
+  test("defaults to the first suggestion only when the input is not already a valid repo target", () => {
+    expect(getDefaultQuickJumpSuggestionIndex(suggestions, "")).toBe(0)
+    expect(getDefaultQuickJumpSuggestionIndex(suggestions, "next")).toBe(0)
+    expect(getDefaultQuickJumpSuggestionIndex(suggestions, "openai/codex")).toBe(-1)
+    expect(getDefaultQuickJumpSuggestionIndex(suggestions, "https://github.com/openai/codex/tree/main")).toBe(-1)
+    expect(getDefaultQuickJumpSuggestionIndex([], "next")).toBe(-1)
+  })
+
+  test("cycles keyboard selection through the suggestion list", () => {
+    expect(getNextQuickJumpSuggestionIndex(-1, suggestions.length, "next")).toBe(0)
+    expect(getNextQuickJumpSuggestionIndex(0, suggestions.length, "previous")).toBe(suggestions.length - 1)
+    expect(getNextQuickJumpSuggestionIndex(suggestions.length - 1, suggestions.length, "next")).toBe(0)
+    expect(getNextQuickJumpSuggestionIndex(1, suggestions.length, "previous")).toBe(0)
+    expect(getNextQuickJumpSuggestionIndex(0, 0, "next")).toBe(-1)
+  })
+})

--- a/test/repo-launcher.test.ts
+++ b/test/repo-launcher.test.ts
@@ -56,6 +56,7 @@ describe("repo launcher parsing", () => {
     expect(parseRepoLauncherInput("https://example.com/openai/codex")).toBeNull()
     expect(parseRepoLauncherInput(".well-known/nodeinfo")).toBeNull()
     expect(parseRepoLauncherInput("admin/.env")).toBeNull()
+    expect(parseRepoLauncherInput("https://discofork.ai/.well-known/nodeinfo")).toBeNull()
   })
 })
 

--- a/web/src/components/quick-jump-dialog.tsx
+++ b/web/src/components/quick-jump-dialog.tsx
@@ -1,14 +1,87 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { ArrowRight, Slash } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  filterRepoLauncherSuggestions,
+  getRepoLauncherSuggestions,
+  REPO_LAUNCHER_SUGGESTION_LABELS,
+  type RepoLauncherSuggestion,
+  type RepoLauncherTarget,
+} from "@/lib/repo-launcher"
+import {
+  getDefaultQuickJumpSuggestionIndex,
+  getNextQuickJumpSuggestionIndex,
+  resolveQuickJumpTarget,
+} from "@/lib/quick-jump"
+
+function QuickJumpSuggestionButton({
+  suggestion,
+  index,
+  active,
+  onHover,
+  onSelect,
+}: {
+  suggestion: RepoLauncherSuggestion
+  index: number
+  active: boolean
+  onHover: (index: number) => void
+  onSelect: (target: RepoLauncherTarget) => void
+}) {
+  return (
+    <button
+      id={`quick-jump-suggestion-${index}`}
+      type="button"
+      role="option"
+      aria-selected={active}
+      onMouseEnter={() => onHover(index)}
+      onClick={() => onSelect(suggestion)}
+      className={`rounded-md border px-3 py-2 text-left transition-colors ${
+        active ? "border-foreground/20 bg-muted/80" : "border-border bg-card hover:bg-muted/70"
+      }`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="truncate text-sm font-semibold text-foreground">{suggestion.fullName}</span>
+        <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {suggestion.sources.map((source) => (
+          <Badge key={source} variant="muted" className="tracking-[0.1em]">
+            {REPO_LAUNCHER_SUGGESTION_LABELS[source]}
+          </Badge>
+        ))}
+      </div>
+    </button>
+  )
+}
 
 export function QuickJumpDialog() {
   const [open, setOpen] = useState(false)
   const [value, setValue] = useState("")
+  const [suggestions, setSuggestions] = useState<RepoLauncherSuggestion[]>([])
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1)
+  const [hasExplicitSuggestionSelection, setHasExplicitSuggestionSelection] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
+
+  const refreshSuggestions = useCallback(() => {
+    setSuggestions(getRepoLauncherSuggestions())
+  }, [])
+
+  const navigateToRepo = useCallback(
+    (target: RepoLauncherTarget) => {
+      setOpen(false)
+      setValue("")
+      setSuggestions([])
+      setActiveSuggestionIndex(-1)
+      setHasExplicitSuggestionSelection(false)
+      router.push(target.canonicalPath)
+    },
+    [router],
+  )
 
   // Open with "/" when not focused on an input
   useEffect(() => {
@@ -32,14 +105,15 @@ export function QuickJumpDialog() {
     return () => document.removeEventListener("keydown", handleKeyDown)
   }, [])
 
-  // Focus input when opening
+  // Focus input when opening and refresh local suggestions
   useEffect(() => {
     if (open) {
       setValue("")
+      refreshSuggestions()
       const frame = requestAnimationFrame(() => inputRef.current?.focus())
       return () => cancelAnimationFrame(frame)
     }
-  }, [open])
+  }, [open, refreshSuggestions])
 
   // Escape closes
   useEffect(() => {
@@ -66,20 +140,59 @@ export function QuickJumpDialog() {
     }
   }, [open])
 
+  const filteredSuggestions = useMemo(
+    () => filterRepoLauncherSuggestions(suggestions, value),
+    [suggestions, value],
+  )
+
+  useEffect(() => {
+    if (!open) {
+      setActiveSuggestionIndex(-1)
+      setHasExplicitSuggestionSelection(false)
+      return
+    }
+
+    setActiveSuggestionIndex(getDefaultQuickJumpSuggestionIndex(filteredSuggestions, value))
+    setHasExplicitSuggestionSelection(false)
+  }, [filteredSuggestions, open, value])
+
+  const submitTarget = useMemo(
+    () =>
+      resolveQuickJumpTarget(value, filteredSuggestions, activeSuggestionIndex, {
+        preferActiveSuggestion: hasExplicitSuggestionSelection,
+      }),
+    [activeSuggestionIndex, filteredSuggestions, hasExplicitSuggestionSelection, value],
+  )
+
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault()
-      const trimmed = value.trim()
-      if (!trimmed) return
-
-      // Basic owner/repo validation
-      const parts = trimmed.split("/")
-      if (parts.length === 2 && parts[0] && parts[1]) {
-        setOpen(false)
-        router.push(`/${parts[0]}/${parts[1]}`)
-      }
+      if (!submitTarget) return
+      navigateToRepo(submitTarget)
     },
-    [value, router],
+    [navigateToRepo, submitTarget],
+  )
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") {
+        return
+      }
+
+      const nextIndex = getNextQuickJumpSuggestionIndex(
+        activeSuggestionIndex,
+        filteredSuggestions.length,
+        e.key === "ArrowDown" ? "next" : "previous",
+      )
+      if (nextIndex === -1) {
+        return
+      }
+
+      e.preventDefault()
+      setActiveSuggestionIndex(nextIndex)
+      setHasExplicitSuggestionSelection(true)
+    },
+    [activeSuggestionIndex, filteredSuggestions.length],
   )
 
   if (!open) {
@@ -95,7 +208,7 @@ export function QuickJumpDialog() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] bg-background/80 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-background/80 pt-[15vh] backdrop-blur-sm"
       onClick={() => setOpen(false)}
     >
       <div
@@ -109,13 +222,17 @@ export function QuickJumpDialog() {
             type="text"
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            placeholder="owner/repo"
+            onFocus={refreshSuggestions}
+            onKeyDown={handleInputKeyDown}
+            placeholder="owner/repo or repo URL"
             className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
             aria-label="Navigate to repository"
+            aria-controls="quick-jump-suggestions"
+            aria-activedescendant={activeSuggestionIndex >= 0 ? `quick-jump-suggestion-${activeSuggestionIndex}` : undefined}
           />
           <button
             type="submit"
-            disabled={!value.trim().includes("/")}
+            disabled={!submitTarget}
             className="rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-30"
             aria-label="Go"
           >
@@ -124,17 +241,48 @@ export function QuickJumpDialog() {
         </form>
         <div className="px-4 py-3">
           <p className="text-xs text-muted-foreground">
-            Type <span className="font-mono font-medium text-foreground">owner/repo</span> and press Enter to navigate directly to the repository brief.
+            Paste <span className="font-mono font-medium text-foreground">owner/repo</span>, a GitHub repo URL, or a Discofork repo URL to jump directly to the repository brief.
           </p>
         </div>
+        {filteredSuggestions.length > 0 ? (
+          <div className="border-t border-border px-4 py-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Quick reopen</div>
+              <p className="text-xs text-muted-foreground">Recent, bookmarked, and watched repos on this device.</p>
+            </div>
+            <div id="quick-jump-suggestions" role="listbox" className="mt-3 grid gap-2">
+              {filteredSuggestions.map((suggestion, index) => (
+                <QuickJumpSuggestionButton
+                  key={suggestion.fullName}
+                  suggestion={suggestion}
+                  index={index}
+                  active={index === activeSuggestionIndex}
+                  onHover={(nextIndex) => {
+                    setActiveSuggestionIndex(nextIndex)
+                    setHasExplicitSuggestionSelection(true)
+                  }}
+                  onSelect={navigateToRepo}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
         <div className="border-t border-border px-4 py-2">
-          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
             <span>
               <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
                 ↵
               </kbd>{" "}
               navigate
             </span>
+            {filteredSuggestions.length > 0 ? (
+              <span>
+                <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
+                  ↑↓
+                </kbd>{" "}
+                select
+              </span>
+            ) : null}
             <span>
               <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
                 esc

--- a/web/src/lib/quick-jump.ts
+++ b/web/src/lib/quick-jump.ts
@@ -1,0 +1,60 @@
+import {
+  parseRepoLauncherInput,
+  type RepoLauncherSuggestion,
+  type RepoLauncherTarget,
+} from "./repo-launcher"
+
+export function getDefaultQuickJumpSuggestionIndex(
+  suggestions: RepoLauncherSuggestion[],
+  input: string,
+): number {
+  if (suggestions.length === 0) {
+    return -1
+  }
+
+  return parseRepoLauncherInput(input.trim()) ? -1 : 0
+}
+
+export function getNextQuickJumpSuggestionIndex(
+  currentIndex: number,
+  suggestionCount: number,
+  direction: "next" | "previous",
+): number {
+  if (suggestionCount <= 0) {
+    return -1
+  }
+
+  if (currentIndex < 0 || currentIndex >= suggestionCount) {
+    return direction === "next" ? 0 : suggestionCount - 1
+  }
+
+  return direction === "next"
+    ? (currentIndex + 1) % suggestionCount
+    : (currentIndex - 1 + suggestionCount) % suggestionCount
+}
+
+export function resolveQuickJumpTarget(
+  input: string,
+  suggestions: RepoLauncherSuggestion[],
+  activeSuggestionIndex: number,
+  options: { preferActiveSuggestion?: boolean } = {},
+): RepoLauncherTarget | null {
+  if (
+    options.preferActiveSuggestion &&
+    activeSuggestionIndex >= 0 &&
+    activeSuggestionIndex < suggestions.length
+  ) {
+    return suggestions[activeSuggestionIndex] ?? null
+  }
+
+  const parsedTarget = parseRepoLauncherInput(input.trim())
+  if (parsedTarget) {
+    return parsedTarget
+  }
+
+  if (activeSuggestionIndex < 0 || activeSuggestionIndex >= suggestions.length) {
+    return null
+  }
+
+  return suggestions[activeSuggestionIndex] ?? null
+}

--- a/web/src/lib/repo-launcher.ts
+++ b/web/src/lib/repo-launcher.ts
@@ -141,8 +141,13 @@ export function parseRepoLauncherInput(raw: string): RepoLauncherTarget | null {
   }
 
   const owner = segments[0]
-  const repo = segments[1].replace(/\.git$/i, "")
-  if (!owner || !repo) {
+  const repoSegment = segments[1]
+  if (!owner || !repoSegment) {
+    return null
+  }
+
+  const repo = repoSegment.replace(/\.git$/i, "")
+  if (!repo) {
     return null
   }
 


### PR DESCRIPTION
Closes #104

## Summary
- reuse the shared repo-launcher parser inside the `/` quick-jump dialog
- show recent, bookmarked, and watched quick-reopen suggestions in the dialog
- keep keyboard navigation consistent by letting explicit arrow-key selection override a typed repo target only when the user intentionally selects a suggestion

## Why this improves Discofork
The slash shortcut now behaves like a real launcher instead of a bare `owner/repo` textbox. People can paste GitHub or Discofork repo URLs directly, reopen repos they already use on the same device, and trust that the highlighted suggestion is the repo Enter will open.

## Validation
- `cd web && npx bun run typecheck`
- `npx bun test test/repo-launcher.test.ts test/quick-jump-dialog.test.ts`
- `npx bun test`
- `cd web && npx bun run build`
- `npx bun run typecheck` *(still fails on pre-existing DOM-global errors in `web/src/lib/history.ts`, `web/src/lib/local-storage.ts`, and `web/src/lib/watches.ts` outside this issue)*

## Review gate
- reviewer-only fallback was used because the full `review-changes` orchestration path was unavailable in this active context
- the first review found a highlighted-vs-submitted quick-jump mismatch
- this PR includes the follow-up fix and the rerun reviewer approved the updated diff

## Risks / follow-ups
- A future component-level interaction test for the dialog could complement the current helper-level regression coverage.

## Exec plan
- `.hermes/plans/2026-04-14-quick-jump-repo-launcher.md`
