### PR TITLE
fix(web): prevent stale command palette results

### DIFF
--- a/test/command-palette-search.test.ts
+++ b/test/command-palette-search.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+
+import { createLatestRequestGuard } from "../web/src/lib/latest-request-guard"
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return {
+    promise,
+    resolve,
+  }
+}
+
+describe("command palette latest-request guard", () => {
+  test("only the newest overlapping search response can apply results", async () => {
+    const guard = createLatestRequestGuard()
+    const applied: string[] = []
+
+    const firstResponse = createDeferred<string>()
+    const firstRequest = guard.begin()
+    const firstTask = firstResponse.promise.then((value) => {
+      if (firstRequest.isCurrent()) {
+        applied.push(value)
+      }
+    })
+
+    const secondResponse = createDeferred<string>()
+    const secondRequest = guard.begin()
+    const secondTask = secondResponse.promise.then((value) => {
+      if (secondRequest.isCurrent()) {
+        applied.push(value)
+      }
+    })
+
+    secondResponse.resolve("newer")
+    firstResponse.resolve("older")
+    await Promise.all([firstTask, secondTask])
+
+    expect(applied).toEqual(["newer"])
+    expect(firstRequest.isAborted()).toBe(true)
+    expect(firstRequest.isCurrent()).toBe(false)
+    expect(secondRequest.isAborted()).toBe(false)
+    expect(secondRequest.isCurrent()).toBe(true)
+  })
+
+  test("invalidate aborts the active request so cleared or changed queries ignore late results", async () => {
+    const guard = createLatestRequestGuard()
+    const applied: string[] = []
+
+    const response = createDeferred<string>()
+    const request = guard.begin()
+    const task = response.promise.then((value) => {
+      if (request.isCurrent()) {
+        applied.push(value)
+      }
+    })
+
+    guard.invalidate()
+    response.resolve("stale")
+    await task
+
+    expect(applied).toEqual([])
+    expect(request.isAborted()).toBe(true)
+    expect(request.isCurrent()).toBe(false)
+  })
+})

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Loader2, Search, Star, X } from "lucide-react"
 
+import { createLatestRequestGuard } from "@/lib/latest-request-guard"
+
 type PaletteResult = {
   fullName: string
   owner: string
@@ -29,7 +31,39 @@ export function CommandPalette() {
   const [loading, setLoading] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const inputRef = useRef<HTMLInputElement>(null)
+  const latestSearchRef = useRef<ReturnType<typeof createLatestRequestGuard> | null>(null)
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  if (latestSearchRef.current === null) {
+    latestSearchRef.current = createLatestRequestGuard()
+  }
+  const latestSearch = latestSearchRef.current
   const router = useRouter()
+
+  const clearPendingSearchTimer = useCallback(() => {
+    if (searchTimerRef.current !== null) {
+      clearTimeout(searchTimerRef.current)
+      searchTimerRef.current = null
+    }
+  }, [])
+
+  const updateQuery = useCallback((nextQuery: string) => {
+    clearPendingSearchTimer()
+    latestSearch.invalidate()
+    setQuery(nextQuery)
+    setResults([])
+    setHighlightedIndex(-1)
+    setLoading(nextQuery.trim().length > 0)
+  }, [clearPendingSearchTimer, latestSearch])
+
+  const closePalette = useCallback(() => {
+    clearPendingSearchTimer()
+    latestSearch.invalidate()
+    setOpen(false)
+    setQuery("")
+    setResults([])
+    setHighlightedIndex(-1)
+    setLoading(false)
+  }, [clearPendingSearchTimer, latestSearch])
 
   // Global shortcut: Cmd+K / Ctrl+K (skip when focus is in an input-like element)
   useEffect(() => {
@@ -45,25 +79,32 @@ export function CommandPalette() {
           return
         }
         e.preventDefault()
-        setOpen((prev) => !prev)
+        if (open) {
+          closePalette()
+        } else {
+          setOpen(true)
+        }
       }
     }
 
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [])
+  }, [closePalette, open])
 
   // Focus input when opening
   useEffect(() => {
     if (open) {
-      setQuery("")
-      setResults([])
-      setHighlightedIndex(-1)
-      // Small delay to ensure the input is rendered
       const frame = requestAnimationFrame(() => inputRef.current?.focus())
       return () => cancelAnimationFrame(frame)
     }
   }, [open])
+
+  useEffect(() => {
+    return () => {
+      clearPendingSearchTimer()
+      latestSearch.invalidate()
+    }
+  }, [clearPendingSearchTimer, latestSearch])
 
   // Escape closes the palette
   useEffect(() => {
@@ -72,13 +113,13 @@ export function CommandPalette() {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault()
-        setOpen(false)
+        closePalette()
       }
     }
 
     document.addEventListener("keydown", handleEscape)
     return () => document.removeEventListener("keydown", handleEscape)
-  }, [open])
+  }, [closePalette, open])
 
   // Prevent body scroll when open
   useEffect(() => {
@@ -92,23 +133,37 @@ export function CommandPalette() {
 
   // Debounced search
   useEffect(() => {
-    if (!query.trim()) {
+    clearPendingSearchTimer()
+
+    if (!open) {
+      return
+    }
+
+    const trimmedQuery = query.trim()
+
+    if (!trimmedQuery) {
       setResults([])
       setLoading(false)
       return
     }
 
     setLoading(true)
-    const timer = setTimeout(async () => {
+    searchTimerRef.current = setTimeout(async () => {
+      searchTimerRef.current = null
+      const request = latestSearch.begin()
+
       try {
         const params = new URLSearchParams({
-          query: query.trim(),
+          query: trimmedQuery,
           status: "ready",
           page: "1",
         })
-        const res = await fetch(`/api/repos?${params}`)
-        if (!res.ok) return
+        const res = await fetch(`/api/repos?${params}`, { signal: request.signal })
+        if (!res.ok || !request.isCurrent()) return
+
         const data = await res.json()
+        if (!request.isCurrent()) return
+
         const items: PaletteResult[] = (data.items ?? []).slice(0, MAX_RESULTS).map(
           (item: Record<string, unknown>) => ({
             fullName: item.fullName,
@@ -120,15 +175,22 @@ export function CommandPalette() {
         )
         setResults(items)
         setHighlightedIndex(items.length > 0 ? 0 : -1)
-      } catch {
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return
+        }
         // Silent fail — palette just stays empty
       } finally {
-        setLoading(false)
+        if (request.isCurrent()) {
+          setLoading(false)
+        }
       }
     }, DEBOUNCE_MS)
 
-    return () => clearTimeout(timer)
-  }, [query])
+    return () => {
+      clearPendingSearchTimer()
+    }
+  }, [clearPendingSearchTimer, open, query])
 
   // Keyboard navigation within results
   const handleInputKeyDown = useCallback(
@@ -142,19 +204,19 @@ export function CommandPalette() {
       } else if (e.key === "Enter" && highlightedIndex >= 0 && highlightedIndex < results.length) {
         e.preventDefault()
         const item = results[highlightedIndex]
-        setOpen(false)
+        closePalette()
         router.push(`/${item.owner}/${item.repo}`)
       }
     },
-    [results, highlightedIndex, router],
+    [closePalette, results, highlightedIndex, router],
   )
 
   const navigateTo = useCallback(
     (owner: string, repo: string) => {
-      setOpen(false)
+      closePalette()
       router.push(`/${owner}/${repo}`)
     },
-    [router],
+    [closePalette, router],
   )
 
   if (!open) return null
@@ -162,7 +224,7 @@ export function CommandPalette() {
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] bg-background/80 backdrop-blur-sm"
-      onClick={() => setOpen(false)}
+      onClick={closePalette}
     >
       <div
         className="relative w-full max-w-lg rounded-lg border border-border bg-card shadow-lg"
@@ -175,7 +237,7 @@ export function CommandPalette() {
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => updateQuery(e.target.value)}
             onKeyDown={handleInputKeyDown}
             placeholder="Search repositories…"
             className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
@@ -184,7 +246,7 @@ export function CommandPalette() {
           {loading && <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />}
           <button
             type="button"
-            onClick={() => setOpen(false)}
+            onClick={closePalette}
             className="rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
             aria-label="Close"
           >

--- a/web/src/lib/latest-request-guard.ts
+++ b/web/src/lib/latest-request-guard.ts
@@ -1,0 +1,65 @@
+export type LatestRequestHandle = {
+  id: number
+  signal: AbortSignal
+  isAborted: () => boolean
+  isCurrent: () => boolean
+}
+
+type AbortControllerLike = {
+  abort: () => void
+  signal: AbortSignal
+}
+
+type ActiveRequest = {
+  controller: AbortControllerLike
+  aborted: boolean
+  id: number
+}
+
+export function createLatestRequestGuard(): {
+  begin: () => LatestRequestHandle
+  invalidate: () => void
+} {
+  let activeRequest: ActiveRequest | null = null
+  let latestRequestId = 0
+
+  const abortActiveRequest = () => {
+    if (!activeRequest || activeRequest.aborted) {
+      return
+    }
+
+    activeRequest.aborted = true
+    activeRequest.controller.abort()
+  }
+
+  const invalidate = () => {
+    latestRequestId += 1
+    abortActiveRequest()
+    activeRequest = null
+  }
+
+  const begin = (): LatestRequestHandle => {
+    latestRequestId += 1
+    abortActiveRequest()
+
+    const request: ActiveRequest = {
+      controller: new AbortController() as unknown as AbortControllerLike,
+      aborted: false,
+      id: latestRequestId,
+    }
+
+    activeRequest = request
+
+    return {
+      id: request.id,
+      signal: request.controller.signal,
+      isAborted: () => request.aborted,
+      isCurrent: () => latestRequestId === request.id && activeRequest === request && !request.aborted,
+    }
+  }
+
+  return {
+    begin,
+    invalidate,
+  }
+}


### PR DESCRIPTION
Closes #107

## Summary
- add a small latest-request guard for the global command palette search flow
- abort and invalidate stale `/api/repos` lookups when the query changes or the palette closes
- clear stale results immediately so outdated matches cannot stay visible or selectable while a newer search is pending
- add focused regression coverage for overlapping request and invalidation behavior

## Why
The site-wide `Cmd+K` command palette could show or select stale repositories when older `/api/repos` responses resolved after a newer query. This made repo navigation feel unreliable and could send users to the wrong brief.

## Validation
- `npx bun test test/command-palette-search.test.ts`
- `cd web && npx bun run typecheck`
- `npx bun run typecheck` *(still fails on pre-existing baseline issues in untouched files: `web/src/lib/history.ts`, `web/src/lib/local-storage.ts`, `web/src/lib/watches.ts`, and `web/src/lib/repo-launcher.ts`)*

## Review
- reviewer-only fallback used because the full `review-changes` orchestration path was unavailable in this environment
- the fallback review surfaced stale-state edge cases around query changes, close/reopen behavior, and debounce timing; this PR includes the follow-up fixes for those findings

## Risks / follow-ups
- focused regression coverage currently targets the request guard helper rather than a full component-level debounce integration test
- the unrelated root typecheck baseline errors remain out of scope for this PR

## Exec plan
- `.hermes/plans/2026-04-15-command-palette-stale-search.md`
