### PR TITLE
feat: make compare page editable

### DIFF
--- a/test/compare-selection.test.ts
+++ b/test/compare-selection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  MAX_COMPARE_REPOS,
+  addCompareSelectionRepo,
+  normalizeCompareSelection,
+  parseCompareSelectionValue,
+  removeCompareSelectionRepo,
+  replaceCompareSelectionRepo,
+} from "../web/src/lib/compare-selection"
+
+describe("compare selection helpers", () => {
+  test("normalizeCompareSelection trims, deduplicates, and caps the selection", () => {
+    expect(
+      normalizeCompareSelection([
+        " vultuk/discofork ",
+        "openai/codex",
+        "vultuk/discofork",
+        "schema-labs-ltd/discofork",
+        "extra/repo",
+      ]),
+    ).toEqual(["vultuk/discofork", "openai/codex", "schema-labs-ltd/discofork"])
+    expect(normalizeCompareSelection(["", "   "])).toEqual([])
+    expect(normalizeCompareSelection(["one/two", "three/four", "five/six"]).length).toBe(MAX_COMPARE_REPOS)
+  })
+
+  test("parseCompareSelectionValue preserves shareable compare URL ordering", () => {
+    expect(parseCompareSelectionValue("vultuk/discofork,openai/codex,schema-labs-ltd/discofork")).toEqual([
+      "vultuk/discofork",
+      "openai/codex",
+      "schema-labs-ltd/discofork",
+    ])
+    expect(parseCompareSelectionValue("vultuk/discofork,,openai/codex")).toEqual([
+      "vultuk/discofork",
+      "openai/codex",
+    ])
+    expect(parseCompareSelectionValue(null)).toEqual([])
+  })
+
+  test("addCompareSelectionRepo appends only when room is available", () => {
+    const initial = ["vultuk/discofork"]
+    expect(addCompareSelectionRepo(initial, "openai/codex")).toEqual(["vultuk/discofork", "openai/codex"])
+    expect(addCompareSelectionRepo(initial, "vultuk/discofork")).toEqual(initial)
+    expect(addCompareSelectionRepo(["a/b", "c/d", "e/f"], "g/h")).toEqual(["a/b", "c/d", "e/f"])
+  })
+
+  test("removeCompareSelectionRepo keeps the remaining compare order", () => {
+    expect(removeCompareSelectionRepo(["a/b", "c/d", "e/f"], "c/d")).toEqual(["a/b", "e/f"])
+    expect(removeCompareSelectionRepo(["a/b", "c/d"], "missing/repo")).toEqual(["a/b", "c/d"])
+  })
+
+  test("replaceCompareSelectionRepo swaps in place and respects the compare cap", () => {
+    expect(replaceCompareSelectionRepo(["a/b", "c/d", "e/f"], "c/d", "g/h")).toEqual(["a/b", "g/h", "e/f"])
+    expect(replaceCompareSelectionRepo(["a/b", "c/d", "e/f"], "c/d", "a/b")).toEqual(["a/b", "e/f"])
+    expect(replaceCompareSelectionRepo(["a/b", "c/d"], null, "e/f")).toEqual(["a/b", "c/d", "e/f"])
+    expect(replaceCompareSelectionRepo(["a/b", "c/d", "e/f"], null, "g/h")).toEqual(["a/b", "c/d", "e/f"])
+  })
+})

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -1,21 +1,58 @@
 "use client"
 
-import { Suspense, useEffect, useState } from "react"
+import { Suspense, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
-import { useSearchParams } from "next/navigation"
-import { ArrowRight, Download, GitCompareArrows } from "lucide-react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { ArrowRight, Download, GitCompareArrows, Plus, RefreshCcw, Trash2, X } from "lucide-react"
 
 import { RepoShell } from "@/components/repo-shell"
 import { Badge } from "@/components/ui/badge"
-import { buttonVariants } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
-import type { CachedRepoView } from "@/lib/repository-service"
-import { getCompareSelection, setCompareSelection } from "@/lib/compare"
+import { Button, buttonVariants } from "@/components/ui/button"
+import {
+  MAX_COMPARE_REPOS,
+  addCompareSelectionRepo,
+  buildCompareHref,
+  getCompareSelection,
+  parseCompareSelectionValue,
+  removeCompareSelectionRepo,
+  replaceCompareSelectionRepo,
+  setCompareSelection,
+} from "@/lib/compare"
 import { exportComparison } from "@/lib/export-comparison"
+import {
+  REPO_LAUNCHER_SUGGESTION_LABELS,
+  getRepoLauncherSuggestions,
+  type RepoLauncherSuggestion,
+} from "@/lib/repo-launcher"
+import type { CachedRepoView } from "@/lib/repository-service"
+import { cn } from "@/lib/utils"
 
 function formatDate(isoString: string): string {
   const date = new Date(isoString)
   return Number.isNaN(date.getTime()) ? isoString : date.toISOString().slice(0, 10)
+}
+
+function formatRelativeTime(dateString: string | null): string {
+  if (!dateString) {
+    return "recently"
+  }
+
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return "just now"
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+  return date.toLocaleDateString()
+}
+
+function selectionsEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((repo, index) => repo === right[index])
 }
 
 function StatCell({ label, values }: { label: string; values: (string | number | null)[] }) {
@@ -73,178 +110,449 @@ function RepoColumnHeader({ view }: { view: CachedRepoView }) {
   )
 }
 
+function ComparePickCard({
+  fullName,
+  view,
+  replacing,
+  onRemove,
+  onToggleReplace,
+}: {
+  fullName: string
+  view?: CachedRepoView
+  replacing: boolean
+  onRemove: (fullName: string) => void
+  onToggleReplace: (fullName: string) => void
+}) {
+  return (
+    <div
+      className={cn(
+        "space-y-4 rounded-md border bg-card p-5 transition-colors",
+        replacing ? "border-primary/50 bg-primary/5" : "border-border",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-2">
+          <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Selected repo</div>
+          {view ? (
+            <Link
+              href={`/${view.owner}/${view.repo}`}
+              className="block truncate text-sm font-semibold text-foreground transition-colors hover:text-primary"
+            >
+              {fullName}
+            </Link>
+          ) : (
+            <div className="truncate text-sm font-semibold text-foreground">{fullName}</div>
+          )}
+          {view ? (
+            <p className="text-xs leading-5 text-muted-foreground line-clamp-3">{view.upstreamSummary}</p>
+          ) : (
+            <p className="text-xs leading-5 text-muted-foreground">
+              Cached comparison data is still loading for this selection.
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onToggleReplace(fullName)}
+            className={cn(
+              buttonVariants({ variant: "outline" }),
+              "gap-1.5 px-3 py-1.5 text-xs",
+              replacing && "border-primary/30 bg-primary/10 text-primary hover:bg-primary/15",
+            )}
+          >
+            <RefreshCcw className="h-3.5 w-3.5" />
+            {replacing ? "Replacing" : "Replace"}
+          </button>
+          <button
+            type="button"
+            onClick={() => onRemove(fullName)}
+            className={cn(
+              buttonVariants({ variant: "ghost" }),
+              "gap-1.5 px-3 py-1.5 text-xs text-muted-foreground hover:text-rose-500",
+            )}
+            aria-label={`Remove ${fullName} from compare`}
+          >
+            <X className="h-3.5 w-3.5" />
+            Remove
+          </button>
+        </div>
+      </div>
+
+      {view ? (
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="muted">{view.stats.stars.toLocaleString()} stars</Badge>
+          <Badge variant="muted">{view.stats.forks.toLocaleString()} forks</Badge>
+          <Badge variant="muted">Cached {formatDate(view.cachedAt)}</Badge>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function EmptyCompareSlot() {
+  return (
+    <div className="flex min-h-[168px] flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-card/50 p-5 text-center">
+      <Plus className="h-5 w-5 text-muted-foreground" />
+      <div className="space-y-1">
+        <div className="text-sm font-semibold text-foreground">Open compare slot</div>
+        <p className="text-xs leading-5 text-muted-foreground">
+          Add a recent, bookmarked, or watched repository below.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function SuggestionCard({
+  suggestion,
+  actionLabel,
+  disabled,
+  onAction,
+}: {
+  suggestion: RepoLauncherSuggestion
+  actionLabel: string
+  disabled: boolean
+  onAction: (suggestion: RepoLauncherSuggestion) => void
+}) {
+  return (
+    <div className="space-y-4 rounded-md border border-border bg-card p-5">
+      <div className="space-y-2">
+        <Link
+          href={suggestion.canonicalPath}
+          className="block truncate text-sm font-semibold text-foreground transition-colors hover:text-primary"
+        >
+          {suggestion.fullName}
+        </Link>
+        <div className="flex flex-wrap gap-2">
+          {suggestion.sources.map((source) => (
+            <Badge key={`${suggestion.fullName}-${source}`} variant="muted">
+              {REPO_LAUNCHER_SUGGESTION_LABELS[source]}
+            </Badge>
+          ))}
+        </div>
+        <p className="text-xs leading-5 text-muted-foreground">
+          Last surfaced {formatRelativeTime(suggestion.lastTouchedAt)} from your local context.
+        </p>
+      </div>
+      <Button variant="outline" className="w-full gap-2" disabled={disabled} onClick={() => onAction(suggestion)}>
+        <Plus className="h-4 w-4" />
+        {actionLabel}
+      </Button>
+    </div>
+  )
+}
+
 function CompareContent() {
+  const router = useRouter()
   const searchParams = useSearchParams()
-  const [repos, setRepos] = useState<CachedRepoView[]>([])
+  const [selection, setSelectionState] = useState<string[]>([])
+  const [repoViews, setRepoViews] = useState<Record<string, CachedRepoView>>({})
+  const [suggestions, setSuggestions] = useState<RepoLauncherSuggestion[]>([])
+  const [replaceTarget, setReplaceTarget] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    const fromUrl = searchParams.get("repos")
-    let repoNames: string[]
+    const fromUrl = parseCompareSelectionValue(searchParams.get("repos"))
+    const nextSelection = fromUrl.length > 0 ? fromUrl : getCompareSelection()
 
-    if (fromUrl) {
-      repoNames = fromUrl.split(",").filter(Boolean).slice(0, 3)
-      setCompareSelection(repoNames)
-    } else {
-      repoNames = getCompareSelection()
+    if (fromUrl.length > 0) {
+      setCompareSelection(fromUrl)
     }
 
-    if (repoNames.length === 0) {
+    setSelectionState((current) => (selectionsEqual(current, nextSelection) ? current : nextSelection))
+    setReplaceTarget((current) => (current && nextSelection.includes(current) ? current : null))
+    setSuggestions(getRepoLauncherSuggestions(12))
+
+    if (fromUrl.length === 0 && nextSelection.length > 0) {
+      router.replace(buildCompareHref(nextSelection), { scroll: false })
+    }
+  }, [router, searchParams])
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (selection.length === 0) {
+      setRepoViews({})
       setLoading(false)
-      return
+      return () => {
+        cancelled = true
+      }
     }
+
+    setLoading(true)
 
     const loadRepos = async () => {
-      const loaded: CachedRepoView[] = []
-
-      for (const fullName of repoNames) {
-        try {
-          const response = await fetch(`/api/repo/${fullName}/brief`)
-          if (response.ok) {
-            const data = await response.json()
-            if (data.kind === "cached") {
-              loaded.push(data)
+      const entries = await Promise.all(
+        selection.map(async (fullName) => {
+          try {
+            const response = await fetch(`/api/repo/${fullName}/brief`)
+            if (!response.ok) {
+              return [fullName, null] as const
             }
+
+            const data = (await response.json()) as CachedRepoView | { kind: string }
+            return [fullName, data.kind === "cached" ? data : null] as const
+          } catch {
+            return [fullName, null] as const
           }
-        } catch {
-          // Skip repos that fail to load
-        }
+        }),
+      )
+
+      if (cancelled) {
+        return
       }
 
-      setRepos(loaded)
+      setRepoViews(
+        Object.fromEntries(entries.filter(([, view]) => view).map(([fullName, view]) => [fullName, view])) as Record<
+          string,
+          CachedRepoView
+        >,
+      )
       setLoading(false)
     }
 
-    loadRepos()
-  }, [searchParams])
+    void loadRepos()
 
-  const columnCount = repos.length
+    return () => {
+      cancelled = true
+    }
+  }, [selection])
 
-  if (loading) {
-    return (
-      <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
-        Loading comparison data...
-      </div>
-    )
+  const loadedRepos = useMemo(
+    () => selection.map((fullName) => repoViews[fullName]).filter((view): view is CachedRepoView => Boolean(view)),
+    [repoViews, selection],
+  )
+
+  const availableSuggestions = useMemo(
+    () => suggestions.filter((suggestion) => !selection.includes(suggestion.fullName)),
+    [selection, suggestions],
+  )
+
+  const compareLimitReached = selection.length >= MAX_COMPARE_REPOS
+  const instruction = replaceTarget
+    ? `Replacing ${replaceTarget}. Pick one of the suggestions below to swap it out in place.`
+    : compareLimitReached
+      ? "You have reached the 3-repo compare limit. Click Replace on a selected repo, then choose a suggestion below."
+      : `Add up to ${MAX_COMPARE_REPOS - selection.length} more repositories from your recent, bookmarked, or watched activity.`
+
+  const persistWorkspace = (nextSelection: string[]) => {
+    const persistedSelection = setCompareSelection(nextSelection)
+    setSelectionState(persistedSelection)
+    setReplaceTarget((current) => (current && persistedSelection.includes(current) ? current : null))
+    router.replace(buildCompareHref(persistedSelection), { scroll: false })
   }
 
-  if (repos.length === 0) {
-    return (
-      <div className="rounded-md border border-border bg-card p-6">
-        <div className="flex items-start gap-4">
-          <GitCompareArrows className="mt-1 h-5 w-5 text-muted-foreground" />
-          <div className="space-y-3">
-            <h2 className="text-base font-semibold text-foreground">No repositories selected</h2>
-            <p className="text-sm leading-7 text-muted-foreground">
-              Go to the repository index and click the compare icon on 2-3 repositories to start a comparison.
-            </p>
-            <Link
-              href="/repos"
-              className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}
-            >
-              Browse repositories
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </div>
-        </div>
-      </div>
-    )
+  const handleRemove = (fullName: string) => {
+    persistWorkspace(removeCompareSelectionRepo(selection, fullName))
   }
+
+  const handleClear = () => {
+    persistWorkspace([])
+  }
+
+  const handleSuggestionAction = (suggestion: RepoLauncherSuggestion) => {
+    const nextSelection = replaceTarget
+      ? replaceCompareSelectionRepo(selection, replaceTarget, suggestion.fullName)
+      : addCompareSelectionRepo(selection, suggestion.fullName)
+
+    persistWorkspace(nextSelection)
+    setReplaceTarget(null)
+  }
+
+  const missingRepoCount = selection.length - loadedRepos.length
 
   return (
     <section className="space-y-6">
-      {/* Export button */}
-      {repos.length >= 2 && (
-        <div className="flex justify-end">
-          <button
-            onClick={() => exportComparison(repos)}
-            className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}
-          >
-            <Download className="h-4 w-4" />
-            Export .md
-          </button>
-        </div>
-      )}
-
-      {/* Column headers */}
-      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-        {repos.map((view) => (
-          <RepoColumnHeader key={view.fullName} view={view} />
-        ))}
-      </div>
-
-      {/* Stats comparison */}
-      <div className="overflow-hidden rounded-md border border-border bg-card p-5">
-        <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground mb-4">
-          Stats
-        </div>
-        <div className="space-y-0">
-          <StatCell label="Stars" values={repos.map((v) => v.stats.stars.toLocaleString())} />
-          <StatCell label="Forks" values={repos.map((v) => v.stats.forks.toLocaleString())} />
-          <StatCell label="Default branch" values={repos.map((v) => v.stats.defaultBranch)} />
-          <StatCell label="Last pushed" values={repos.map((v) => formatDate(v.stats.lastPushedAt))} />
-          <StatCell label="Cached at" values={repos.map((v) => formatDate(v.cachedAt))} />
-          <StatCell label="Fork briefs" values={repos.map((v) => String(v.forks.length))} />
-        </div>
-      </div>
-
-      {/* Recommendations comparison */}
-      <div className="overflow-hidden rounded-md border border-border bg-card p-5">
-        <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground mb-4">
-          Fork recommendations
-        </div>
-        <div className="space-y-0">
-          <RecommendationRow
-            label="Best maintained"
-            values={repos.map((v) => v.recommendations.bestMaintained)}
-          />
-          <RecommendationRow
-            label="Closest upstream"
-            values={repos.map((v) => v.recommendations.closestToUpstream)}
-          />
-          <RecommendationRow
-            label="Most features"
-            values={repos.map((v) => v.recommendations.mostFeatureRich)}
-          />
-          <RecommendationRow
-            label="Most opinionated"
-            values={repos.map((v) => v.recommendations.mostOpinionated)}
-          />
-        </div>
-      </div>
-
-      {/* Fork comparison summary */}
-      {repos.some((v) => v.forks.length > 0) && (
-        <div className="overflow-hidden rounded-md border border-border bg-card p-5">
-          <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground mb-4">
-            Top forks
+      <div className="space-y-5 rounded-md border border-border bg-card p-5">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Workspace</div>
+            <h2 className="text-base font-semibold text-foreground">
+              {selection.length > 0 ? `${selection.length} of ${MAX_COMPARE_REPOS} compare slots filled` : "No repositories selected yet"}
+            </h2>
+            <p className="text-sm leading-6 text-muted-foreground">{instruction}</p>
           </div>
-          <div
-            className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-          >
-            {repos.map((view) => (
-              <div key={view.fullName} className="space-y-3">
-                {view.forks.slice(0, 3).map((fork) => (
-                  <div key={fork.fullName} className="rounded-md border border-border bg-muted/70 p-4">
-                    <div className="text-sm font-medium text-foreground">{fork.fullName}</div>
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      <Badge variant={fork.maintenance === "active" ? "success" : "muted"}>
-                        {fork.maintenance}
-                      </Badge>
-                      <Badge variant="muted">{fork.changeMagnitude}</Badge>
-                    </div>
-                    <p className="mt-2 text-xs leading-5 text-muted-foreground line-clamp-2">
-                      {fork.summary}
-                    </p>
-                  </div>
-                ))}
-                {view.forks.length === 0 && (
-                  <div className="text-sm text-muted-foreground">No fork data</div>
-                )}
-              </div>
+          {selection.length > 0 ? (
+            <button
+              type="button"
+              onClick={handleClear}
+              className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs text-muted-foreground hover:text-rose-500")}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Clear all
+            </button>
+          ) : null}
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          {selection.map((fullName) => (
+            <ComparePickCard
+              key={fullName}
+              fullName={fullName}
+              view={repoViews[fullName]}
+              replacing={replaceTarget === fullName}
+              onRemove={handleRemove}
+              onToggleReplace={(target) => setReplaceTarget((current) => (current === target ? null : target))}
+            />
+          ))}
+          {Array.from({ length: Math.max(MAX_COMPARE_REPOS - selection.length, 0) }).map((_, index) => (
+            <EmptyCompareSlot key={`empty-slot-${index}`} />
+          ))}
+        </div>
+
+        {missingRepoCount > 0 ? (
+          <div className="rounded-md border border-dashed border-border bg-background/40 px-4 py-3 text-sm text-muted-foreground">
+            {missingRepoCount} selected {missingRepoCount === 1 ? "repository is" : "repositories are"} still loading or missing cached
+            compare data. You can keep editing the selection while those responses resolve.
+          </div>
+        ) : null}
+      </div>
+
+      {availableSuggestions.length > 0 ? (
+        <div className="space-y-4 rounded-md border border-border bg-card p-5">
+          <div className="space-y-1">
+            <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Suggestions</div>
+            <h2 className="text-base font-semibold text-foreground">Add or replace from local context</h2>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Suggestions are sourced from repositories you recently viewed, bookmarked, or watched in this browser.
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {availableSuggestions.map((suggestion) => {
+              const disabled = compareLimitReached && !replaceTarget
+              const actionLabel = replaceTarget ? `Replace ${replaceTarget}` : compareLimitReached ? "Choose a repo above first" : "Add to compare"
+
+              return (
+                <SuggestionCard
+                  key={suggestion.fullName}
+                  suggestion={suggestion}
+                  actionLabel={actionLabel}
+                  disabled={disabled}
+                  onAction={handleSuggestionAction}
+                />
+              )
+            })}
+          </div>
+        </div>
+      ) : selection.length === 0 ? (
+        <div className="rounded-md border border-border bg-card p-6">
+          <div className="flex items-start gap-4">
+            <GitCompareArrows className="mt-1 h-5 w-5 text-muted-foreground" />
+            <div className="space-y-3">
+              <h2 className="text-base font-semibold text-foreground">No local compare suggestions yet</h2>
+              <p className="text-sm leading-7 text-muted-foreground">
+                Browse the repository index to build your first compare set, then come back here to keep editing it in place.
+              </p>
+              <Link href="/repos" className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}>
+                Browse repositories
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+          Loading comparison data...
+        </div>
+      ) : loadedRepos.length === 0 ? (
+        <div className="rounded-md border border-border bg-card p-6">
+          <div className="flex items-start gap-4">
+            <GitCompareArrows className="mt-1 h-5 w-5 text-muted-foreground" />
+            <div className="space-y-3">
+              <h2 className="text-base font-semibold text-foreground">No cached comparison data available yet</h2>
+              <p className="text-sm leading-7 text-muted-foreground">
+                Keep editing the compare lineup here, or browse more repositories to choose entries that already have cached briefs.
+              </p>
+              <Link href="/repos" className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}>
+                Browse repositories
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          {loadedRepos.length >= 2 ? (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => exportComparison(loadedRepos)}
+                className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}
+              >
+                <Download className="h-4 w-4" />
+                Export .md
+              </button>
+            </div>
+          ) : null}
+
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {loadedRepos.map((view) => (
+              <RepoColumnHeader key={view.fullName} view={view} />
             ))}
           </div>
-        </div>
+
+          <div className="overflow-hidden rounded-md border border-border bg-card p-5">
+            <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Stats</div>
+            <div className="space-y-0">
+              <StatCell label="Stars" values={loadedRepos.map((view) => view.stats.stars.toLocaleString())} />
+              <StatCell label="Forks" values={loadedRepos.map((view) => view.stats.forks.toLocaleString())} />
+              <StatCell label="Default branch" values={loadedRepos.map((view) => view.stats.defaultBranch)} />
+              <StatCell label="Last pushed" values={loadedRepos.map((view) => formatDate(view.stats.lastPushedAt))} />
+              <StatCell label="Cached at" values={loadedRepos.map((view) => formatDate(view.cachedAt))} />
+              <StatCell label="Fork briefs" values={loadedRepos.map((view) => String(view.forks.length))} />
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-md border border-border bg-card p-5">
+            <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
+              Fork recommendations
+            </div>
+            <div className="space-y-0">
+              <RecommendationRow
+                label="Best maintained"
+                values={loadedRepos.map((view) => view.recommendations.bestMaintained)}
+              />
+              <RecommendationRow
+                label="Closest upstream"
+                values={loadedRepos.map((view) => view.recommendations.closestToUpstream)}
+              />
+              <RecommendationRow
+                label="Most features"
+                values={loadedRepos.map((view) => view.recommendations.mostFeatureRich)}
+              />
+              <RecommendationRow
+                label="Most opinionated"
+                values={loadedRepos.map((view) => view.recommendations.mostOpinionated)}
+              />
+            </div>
+          </div>
+
+          {loadedRepos.some((view) => view.forks.length > 0) ? (
+            <div className="overflow-hidden rounded-md border border-border bg-card p-5">
+              <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Top forks</div>
+              <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+                {loadedRepos.map((view) => (
+                  <div key={view.fullName} className="space-y-3">
+                    {view.forks.slice(0, 3).map((fork) => (
+                      <div key={fork.fullName} className="rounded-md border border-border bg-muted/70 p-4">
+                        <div className="text-sm font-medium text-foreground">{fork.fullName}</div>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Badge variant={fork.maintenance === "active" ? "success" : "muted"}>{fork.maintenance}</Badge>
+                          <Badge variant="muted">{fork.changeMagnitude}</Badge>
+                        </div>
+                        <p className="mt-2 text-xs leading-5 text-muted-foreground line-clamp-2">{fork.summary}</p>
+                      </div>
+                    ))}
+                    {view.forks.length === 0 ? <div className="text-sm text-muted-foreground">No fork data</div> : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </>
       )}
     </section>
   )
@@ -255,10 +563,16 @@ export default function ComparePage() {
     <RepoShell
       eyebrow="Repository comparison"
       title="Compare repositories side by side."
-      description="Select 2-3 repositories from the repos list to compare their stats, summaries, and fork recommendations."
+      description="Manage your active comparison directly on this page, remove or replace selections in place, and seed new compare sets from recent, bookmarked, or watched repositories."
       compact
     >
-      <Suspense fallback={<div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">Loading comparison data...</div>}>
+      <Suspense
+        fallback={
+          <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+            Loading comparison data...
+          </div>
+        }
+      >
         <CompareContent />
       </Suspense>
     </RepoShell>

--- a/web/src/components/compare-toggle.tsx
+++ b/web/src/components/compare-toggle.tsx
@@ -1,11 +1,23 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
-import { useRouter } from "next/navigation"
 import { GitCompareArrows } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { isInCompare, toggleCompareRepo, getCompareSelection, buildCompareHref } from "@/lib/compare"
+import { COMPARE_SELECTION_EVENT, MAX_COMPARE_REPOS, buildCompareHref, getCompareSelection, toggleCompareRepo } from "@/lib/compare"
+
+function syncCompareSelection(
+  setRepos: (repos: string[]) => void,
+  fullName?: string,
+  setSelected?: (selected: boolean) => void,
+  reposOverride?: string[],
+): void {
+  const repos = reposOverride ?? getCompareSelection()
+  setRepos(repos)
+  if (fullName && setSelected) {
+    setSelected(repos.includes(fullName))
+  }
+}
 
 export function CompareToggle({
   fullName,
@@ -14,26 +26,44 @@ export function CompareToggle({
   fullName: string
   showLabel?: boolean
 }) {
-  const router = useRouter()
   const [selected, setSelected] = useState(false)
-  const [count, setCount] = useState(0)
+  const [repos, setRepos] = useState<string[]>([])
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     setMounted(true)
-    setSelected(isInCompare(fullName))
-    setCount(getCompareSelection().length)
+    syncCompareSelection(setRepos, fullName, setSelected)
+
+    const handleSelectionChange = (event?: Event) => {
+      const repos = event instanceof CustomEvent ? event.detail?.repos : undefined
+      syncCompareSelection(setRepos, fullName, setSelected, repos)
+    }
+
+    window.addEventListener("storage", handleSelectionChange)
+    window.addEventListener(COMPARE_SELECTION_EVENT, handleSelectionChange as EventListener)
+
+    return () => {
+      window.removeEventListener("storage", handleSelectionChange)
+      window.removeEventListener(COMPARE_SELECTION_EVENT, handleSelectionChange as EventListener)
+    }
   }, [fullName])
+
+  const atCapacity = repos.length >= MAX_COMPARE_REPOS && !selected
 
   const handleToggle = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
       e.stopPropagation()
+
+      if (atCapacity) {
+        return
+      }
+
       const next = toggleCompareRepo(fullName)
+      setRepos(next)
       setSelected(next.includes(fullName))
-      setCount(next.length)
     },
-    [fullName],
+    [atCapacity, fullName],
   )
 
   if (!mounted) {
@@ -53,17 +83,19 @@ export function CompareToggle({
     <button
       type="button"
       onClick={handleToggle}
+      aria-disabled={atCapacity}
       className={cn(
         "flex items-center gap-1.5 rounded-md p-1.5 transition-colors",
+        atCapacity && !selected && "cursor-not-allowed opacity-50",
         selected
           ? "bg-primary/10 text-primary hover:bg-primary/20"
           : "text-muted-foreground hover:bg-muted hover:text-foreground",
       )}
-      aria-label={selected ? "Remove from compare" : "Add to compare"}
+      aria-label={selected ? "Remove from compare" : atCapacity ? "Compare limit reached" : "Add to compare"}
     >
       <GitCompareArrows className="h-3.5 w-3.5" />
       {showLabel ? (
-        <span className="text-xs">{selected ? "Remove" : "Compare"}</span>
+        <span className="text-xs">{selected ? "Remove" : atCapacity ? "Limit reached" : "Compare"}</span>
       ) : null}
     </button>
   )
@@ -77,18 +109,17 @@ export function CompareBar() {
     setMounted(true)
     setRepos(getCompareSelection())
 
-    const handleStorage = () => {
-      setRepos(getCompareSelection())
+    const handleSelectionChange = (event?: Event) => {
+      const repos = event instanceof CustomEvent ? event.detail?.repos ?? getCompareSelection() : getCompareSelection()
+      setRepos(repos)
     }
 
-    window.addEventListener("storage", handleStorage)
-    const interval = setInterval(() => {
-      setRepos(getCompareSelection())
-    }, 500)
+    window.addEventListener("storage", handleSelectionChange)
+    window.addEventListener(COMPARE_SELECTION_EVENT, handleSelectionChange as EventListener)
 
     return () => {
-      window.removeEventListener("storage", handleStorage)
-      clearInterval(interval)
+      window.removeEventListener("storage", handleSelectionChange)
+      window.removeEventListener(COMPARE_SELECTION_EVENT, handleSelectionChange as EventListener)
     }
   }, [])
 

--- a/web/src/lib/compare-selection.ts
+++ b/web/src/lib/compare-selection.ts
@@ -1,0 +1,80 @@
+export const MAX_COMPARE_REPOS = 3
+
+export type CompareSelection = string[]
+
+function normalizeCompareRepoName(fullName: string): string | null {
+  const normalized = fullName.trim()
+  return normalized ? normalized : null
+}
+
+export function normalizeCompareSelection(repos: CompareSelection): CompareSelection {
+  const normalized: string[] = []
+
+  for (const repo of repos) {
+    const fullName = normalizeCompareRepoName(repo)
+    if (!fullName || normalized.includes(fullName)) {
+      continue
+    }
+
+    normalized.push(fullName)
+    if (normalized.length === MAX_COMPARE_REPOS) {
+      break
+    }
+  }
+
+  return normalized
+}
+
+export function parseCompareSelectionValue(value: string | null | undefined): CompareSelection {
+  if (!value) {
+    return []
+  }
+
+  return normalizeCompareSelection(value.split(","))
+}
+
+export function addCompareSelectionRepo(repos: CompareSelection, fullName: string): CompareSelection {
+  const current = normalizeCompareSelection(repos)
+  const nextRepo = normalizeCompareRepoName(fullName)
+
+  if (!nextRepo || current.includes(nextRepo) || current.length >= MAX_COMPARE_REPOS) {
+    return current
+  }
+
+  return [...current, nextRepo]
+}
+
+export function removeCompareSelectionRepo(repos: CompareSelection, fullName: string): CompareSelection {
+  const current = normalizeCompareSelection(repos)
+  const target = normalizeCompareRepoName(fullName)
+
+  if (!target) {
+    return current
+  }
+
+  return current.filter((repo) => repo !== target)
+}
+
+export function replaceCompareSelectionRepo(
+  repos: CompareSelection,
+  currentFullName: string | null | undefined,
+  nextFullName: string,
+): CompareSelection {
+  const current = normalizeCompareSelection(repos)
+  const nextRepo = normalizeCompareRepoName(nextFullName)
+  const target = normalizeCompareRepoName(currentFullName ?? "")
+
+  if (!nextRepo) {
+    return current
+  }
+
+  if (!target || !current.includes(target)) {
+    return addCompareSelectionRepo(current, nextRepo)
+  }
+
+  if (target === nextRepo) {
+    return current
+  }
+
+  return normalizeCompareSelection(current.map((repo) => (repo === target ? nextRepo : repo)))
+}

--- a/web/src/lib/compare.ts
+++ b/web/src/lib/compare.ts
@@ -1,21 +1,42 @@
+import {
+  MAX_COMPARE_REPOS,
+  addCompareSelectionRepo,
+  normalizeCompareSelection,
+  parseCompareSelectionValue,
+  removeCompareSelectionRepo,
+  replaceCompareSelectionRepo,
+  type CompareSelection,
+} from "./compare-selection"
+
 const COMPARE_STORAGE_KEY = "discofork-compare"
 
-export type CompareSelection = string[]
+export {
+  MAX_COMPARE_REPOS,
+  addCompareSelectionRepo,
+  normalizeCompareSelection,
+  parseCompareSelectionValue,
+  removeCompareSelectionRepo,
+  replaceCompareSelectionRepo,
+  type CompareSelection,
+}
 
-export function getCompareSelection(): CompareSelection {
+export const COMPARE_SELECTION_EVENT = "discofork:compare-selection-change"
+
+function emitCompareSelectionChange(repos: CompareSelection): void {
   if (typeof window === "undefined") {
-    return []
+    return
   }
 
-  try {
-    const params = new URLSearchParams(window.location.search)
-    const fromUrl = params.get("repos")
-    if (fromUrl) {
-      const repos = fromUrl.split(",").filter(Boolean)
-      return repos.slice(0, 3)
-    }
-  } catch {
-    // Fall through to localStorage
+  window.dispatchEvent(
+    new CustomEvent<{ repos: CompareSelection }>(COMPARE_SELECTION_EVENT, {
+      detail: { repos },
+    }),
+  )
+}
+
+function readStoredCompareSelection(): CompareSelection {
+  if (typeof window === "undefined") {
+    return []
   }
 
   try {
@@ -24,36 +45,65 @@ export function getCompareSelection(): CompareSelection {
       return []
     }
 
-    const parsed = JSON.parse(raw) as CompareSelection
-    return Array.isArray(parsed) ? parsed.slice(0, 3) : []
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed) ? normalizeCompareSelection(parsed.filter((value): value is string => typeof value === "string")) : []
   } catch {
     return []
   }
 }
 
-export function setCompareSelection(repos: CompareSelection): void {
-  const trimmed = repos.slice(0, 3)
-  if (typeof window !== "undefined") {
-    localStorage.setItem(COMPARE_STORAGE_KEY, JSON.stringify(trimmed))
+export function getCompareSelection(): CompareSelection {
+  if (typeof window === "undefined") {
+    return []
   }
+
+  try {
+    const fromUrl = new URLSearchParams(window.location.search).get("repos")
+    const parsedFromUrl = parseCompareSelectionValue(fromUrl)
+    if (parsedFromUrl.length > 0) {
+      return parsedFromUrl
+    }
+  } catch {
+    // Fall through to localStorage.
+  }
+
+  return readStoredCompareSelection()
+}
+
+export function setCompareSelection(repos: CompareSelection): CompareSelection {
+  const next = normalizeCompareSelection(repos)
+
+  if (typeof window !== "undefined") {
+    localStorage.setItem(COMPARE_STORAGE_KEY, JSON.stringify(next))
+    emitCompareSelectionChange(next)
+  }
+
+  return next
+}
+
+export function removeCompareRepo(fullName: string): CompareSelection {
+  return setCompareSelection(removeCompareSelectionRepo(getCompareSelection(), fullName))
+}
+
+export function clearCompareSelection(): CompareSelection {
+  return setCompareSelection([])
+}
+
+export function replaceCompareRepo(
+  currentFullName: string | null | undefined,
+  nextFullName: string,
+): CompareSelection {
+  return setCompareSelection(replaceCompareSelectionRepo(getCompareSelection(), currentFullName, nextFullName))
 }
 
 export function toggleCompareRepo(fullName: string): CompareSelection {
   const current = getCompareSelection()
 
   if (current.includes(fullName)) {
-    const next = current.filter((name) => name !== fullName)
-    setCompareSelection(next)
-    return next
+    return removeCompareRepo(fullName)
   }
 
-  if (current.length >= 3) {
-    return current
-  }
-
-  const next = [...current, fullName]
-  setCompareSelection(next)
-  return next
+  return setCompareSelection(addCompareSelectionRepo(current, fullName))
 }
 
 export function isInCompare(fullName: string): boolean {
@@ -61,9 +111,10 @@ export function isInCompare(fullName: string): boolean {
 }
 
 export function buildCompareHref(repos: CompareSelection): string {
-  if (repos.length === 0) {
+  const normalized = normalizeCompareSelection(repos)
+  if (normalized.length === 0) {
     return "/compare"
   }
 
-  return `/compare?repos=${encodeURIComponent(repos.join(","))}`
+  return `/compare?repos=${encodeURIComponent(normalized.join(","))}`
 }


### PR DESCRIPTION
Closes #109

## Summary
- turn `/compare` into an editable workspace with removable compare picks and open slots
- add local recent/bookmarked/watched suggestions for building or replacing compare selections in place
- replace compare polling with event-driven selection sync and add focused compare helper tests

## Validation
- `npx bun test test/compare-selection.test.ts`
- `cd web && npx bun run typecheck`
- `cd web && npx bun run build`
- `npx bun run typecheck` *(fails on the existing root baseline in `web/src/lib/history.ts`, `web/src/lib/local-storage.ts`, `web/src/lib/repo-launcher.ts`, and `web/src/lib/watches.ts`; same failure reproduces on current `main`)*

## Review
- `review-changes` full orchestration was unavailable from the execplan subagent context, so I used the documented reviewer-only fallback against a canonical local diff packet
- reviewer-only findings about stale URL/state interactions and compare-capacity click handling were fixed in this branch
- the remaining reviewer-only note about bare `/compare` reviving the stored compare set reflects pre-existing compare-page persistence behavior, so this PR preserves it intentionally
