### PR TITLE
feat(watched): surface fresh cache activity

### DIFF
--- a/test/watches.test.ts
+++ b/test/watches.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  WATCH_ACTIVITY_BATCH_SIZE,
+  chunkWatchFullNames,
+  getWatchActivity,
+  sortWatchesByActivity,
+  type WatchActivitySource,
+  type WatchEntry,
+} from "../web/src/lib/watches"
+
+const BASE_WATCH: WatchEntry = {
+  fullName: "schema-labs-ltd/discofork",
+  owner: "schema-labs-ltd",
+  repo: "discofork",
+  watchedAt: "2026-04-10T08:00:00Z",
+  lastVisitedAt: "2026-04-14T22:00:00Z",
+}
+
+describe("watch activity helpers", () => {
+  test("derives updated status when cached activity is newer than the last visit", () => {
+    expect(
+      getWatchActivity(BASE_WATCH, {
+        status: "cached",
+        cachedAt: "2026-04-15T08:30:00Z",
+      }),
+    ).toEqual({
+      status: "updated",
+      cachedAt: "2026-04-15T08:30:00Z",
+      hasUpdate: true,
+    })
+  })
+
+  test("distinguishes cached, missing, and unknown activity states", () => {
+    expect(
+      getWatchActivity(BASE_WATCH, {
+        status: "cached",
+        cachedAt: "2026-04-14T20:30:00Z",
+      }),
+    ).toEqual({
+      status: "cached",
+      cachedAt: "2026-04-14T20:30:00Z",
+      hasUpdate: false,
+    })
+
+    expect(
+      getWatchActivity(BASE_WATCH, {
+        status: "missing",
+        cachedAt: null,
+      }),
+    ).toEqual({
+      status: "missing",
+      cachedAt: null,
+      hasUpdate: false,
+    })
+
+    expect(
+      getWatchActivity(BASE_WATCH, {
+        status: "unknown",
+        cachedAt: null,
+      }),
+    ).toEqual({
+      status: "unknown",
+      cachedAt: null,
+      hasUpdate: false,
+    })
+  })
+
+  test("prioritizes updated watches and keeps non-updated entries stable", () => {
+    const watches: WatchEntry[] = [
+      {
+        fullName: "owner/unchanged-one",
+        owner: "owner",
+        repo: "unchanged-one",
+        watchedAt: "2026-04-10T08:00:00Z",
+        lastVisitedAt: "2026-04-14T22:00:00Z",
+      },
+      {
+        fullName: "owner/updated-older",
+        owner: "owner",
+        repo: "updated-older",
+        watchedAt: "2026-04-10T09:00:00Z",
+        lastVisitedAt: "2026-04-14T12:00:00Z",
+      },
+      {
+        fullName: "owner/updated-newer",
+        owner: "owner",
+        repo: "updated-newer",
+        watchedAt: "2026-04-10T10:00:00Z",
+        lastVisitedAt: "2026-04-14T12:30:00Z",
+      },
+      {
+        fullName: "owner/unknown",
+        owner: "owner",
+        repo: "unknown",
+        watchedAt: "2026-04-10T11:00:00Z",
+        lastVisitedAt: "2026-04-14T23:00:00Z",
+      },
+    ]
+
+    const activityByFullName: Record<string, WatchActivitySource> = {
+      "owner/unchanged-one": {
+        status: "cached",
+        cachedAt: "2026-04-14T20:00:00Z",
+      },
+      "owner/updated-older": {
+        status: "cached",
+        cachedAt: "2026-04-15T06:00:00Z",
+      },
+      "owner/updated-newer": {
+        status: "cached",
+        cachedAt: "2026-04-15T07:00:00Z",
+      },
+      "owner/unknown": {
+        status: "unknown",
+        cachedAt: null,
+      },
+    }
+
+    const sorted = sortWatchesByActivity(watches, activityByFullName)
+
+    expect(sorted.map((entry) => entry.fullName)).toEqual([
+      "owner/updated-newer",
+      "owner/updated-older",
+      "owner/unchanged-one",
+      "owner/unknown",
+    ])
+  })
+
+  test("chunks large watch lists so activity lookups can cover every repo", () => {
+    const fullNames = Array.from({ length: WATCH_ACTIVITY_BATCH_SIZE + 1 }, (_, index) => `owner/repo-${index + 1}`)
+
+    expect(chunkWatchFullNames(fullNames)).toEqual([
+      fullNames.slice(0, WATCH_ACTIVITY_BATCH_SIZE),
+      fullNames.slice(WATCH_ACTIVITY_BATCH_SIZE),
+    ])
+  })
+})

--- a/web/src/app/api/watched/activity/route.ts
+++ b/web/src/app/api/watched/activity/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server"
+
+import { WATCH_ACTIVITY_BATCH_SIZE } from "@/lib/watches"
+import { getRepoCacheActivities } from "@/lib/server/reports"
+
+type WatchActivityRequest = {
+  repos?: unknown
+}
+
+function normalizeRepoNames(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const normalized = value
+    .filter((repo): repo is string => typeof repo === "string")
+    .map((repo) => repo.trim())
+    .filter(Boolean)
+
+  return [...new Set(normalized)].slice(0, WATCH_ACTIVITY_BATCH_SIZE)
+}
+
+export async function POST(request: Request) {
+  let payload: WatchActivityRequest | null = null
+
+  try {
+    payload = (await request.json()) as WatchActivityRequest
+  } catch {
+    return NextResponse.json({ error: "Invalid watch activity payload." }, { status: 400 })
+  }
+
+  const fullNames = normalizeRepoNames(payload?.repos)
+
+  if (fullNames.length === 0) {
+    return NextResponse.json({ activities: {} })
+  }
+
+  try {
+    const activities = await getRepoCacheActivities(fullNames)
+    return NextResponse.json({ activities })
+  } catch {
+    return NextResponse.json({ error: "Could not load watch activity." }, { status: 500 })
+  }
+}

--- a/web/src/app/watched/page.tsx
+++ b/web/src/app/watched/page.tsx
@@ -1,23 +1,142 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
-import { ArrowRight, Eye, Trash2 } from "lucide-react"
+import { ArrowRight, Eye, RefreshCw, Trash2 } from "lucide-react"
 
 import { RepoShell } from "@/components/repo-shell"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
+import {
+  chunkWatchFullNames,
+  getWatchActivity,
+  type WatchActivitySource,
+  type WatchEntry,
+  getWatches,
+  removeWatch,
+  sortWatchesByActivity,
+} from "@/lib/watches"
 import { cn } from "@/lib/utils"
-import { type WatchEntry, getWatches, removeWatch } from "@/lib/watches"
+
+type WatchedActivityResponse = {
+  activities?: Record<string, WatchActivitySource>
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr)
+  return Number.isNaN(date.getTime()) ? dateStr : date.toLocaleDateString()
+}
+
+function formatRelativeTime(dateStr: string | null): string | null {
+  if (!dateStr) {
+    return null
+  }
+
+  const date = new Date(dateStr)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return "just now"
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+  return date.toLocaleDateString()
+}
+
+function buildUnknownActivityMap(watches: WatchEntry[]): Record<string, WatchActivitySource> {
+  return Object.fromEntries(
+    watches.map((watch) => [
+      watch.fullName,
+      {
+        status: "unknown" as const,
+        cachedAt: null,
+      },
+    ]),
+  )
+}
 
 export default function WatchedPage() {
   const [watches, setWatches] = useState<WatchEntry[]>([])
+  const [activityByFullName, setActivityByFullName] = useState<Record<string, WatchActivitySource>>({})
+  const [activityLoaded, setActivityLoaded] = useState(false)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     setMounted(true)
     setWatches(getWatches())
   }, [])
+
+  useEffect(() => {
+    if (!mounted) {
+      return
+    }
+
+    if (watches.length === 0) {
+      setActivityByFullName({})
+      setActivityLoaded(true)
+      return
+    }
+
+    let cancelled = false
+    setActivityLoaded(false)
+
+    async function loadActivity() {
+      const nextActivity = buildUnknownActivityMap(watches)
+      const batches = chunkWatchFullNames(watches.map((watch) => watch.fullName))
+
+      await Promise.all(
+        batches.map(async (batch) => {
+          try {
+            const response = await fetch("/api/watched/activity", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({ repos: batch }),
+              cache: "no-store",
+            })
+
+            if (!response.ok) {
+              return
+            }
+
+            const data = (await response.json()) as WatchedActivityResponse
+            Object.assign(nextActivity, data.activities ?? {})
+          } catch {
+            // Leave this batch as unknown so partial failures stay visible.
+          }
+        }),
+      )
+
+      if (!cancelled) {
+        setActivityByFullName(nextActivity)
+        setActivityLoaded(true)
+      }
+    }
+
+    void loadActivity()
+
+    return () => {
+      cancelled = true
+    }
+  }, [mounted, watches])
+
+  const watchRows = useMemo(() => {
+    const sortedWatches = sortWatchesByActivity(watches, activityByFullName)
+    return sortedWatches.map((watch) => ({
+      watch,
+      activity: getWatchActivity(watch, activityByFullName[watch.fullName]),
+    }))
+  }, [watches, activityByFullName])
+
+  const updatedCount = watchRows.filter((row) => row.activity.status === "updated").length
 
   const handleRemove = (fullName: string) => {
     removeWatch(fullName)
@@ -56,45 +175,98 @@ export default function WatchedPage() {
             </div>
           </div>
         ) : (
-          <div className="overflow-hidden rounded-md border border-border bg-card">
-            {watches.map((watch) => (
-              <div
-                key={watch.fullName}
-                className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
-              >
-                <div className="min-w-0 flex-1 space-y-1">
-                  <Link
-                    href={`/${watch.owner}/${watch.repo}`}
-                    className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+          <>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span className="text-sm text-muted-foreground">
+                {updatedCount > 0
+                  ? `${updatedCount} watched ${updatedCount === 1 ? "repository has" : "repositories have"} fresh cache activity`
+                  : `${watches.length} watched ${watches.length === 1 ? "repository" : "repositories"}`}
+              </span>
+              {!activityLoaded ? (
+                <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                  <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                  Checking cached activity…
+                </span>
+              ) : null}
+            </div>
+            <div className="overflow-hidden rounded-md border border-border bg-card">
+              {watchRows.map(({ watch, activity }) => {
+                const cachedFreshness = formatRelativeTime(activity.cachedAt)
+
+                return (
+                  <div
+                    key={watch.fullName}
+                    className={cn(
+                      "flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0",
+                      activity.status === "updated" && "bg-emerald-500/5",
+                    )}
                   >
-                    {watch.fullName}
-                  </Link>
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                    <span>Watching since {new Date(watch.watchedAt).toLocaleDateString()}</span>
-                    <span>·</span>
-                    <span>Last visited {new Date(watch.lastVisitedAt).toLocaleDateString()}</span>
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Link
+                          href={`/${watch.owner}/${watch.repo}`}
+                          className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                        >
+                          {watch.fullName}
+                        </Link>
+                        {activity.status === "updated" ? <Badge variant="success">Updated</Badge> : null}
+                        {activity.status === "cached" ? (
+                          <Badge variant="muted">Cached {cachedFreshness ?? formatDate(activity.cachedAt ?? "")}</Badge>
+                        ) : null}
+                        {activity.status === "missing" && activityLoaded ? (
+                          <Badge variant="muted">No cached snapshot yet</Badge>
+                        ) : null}
+                        {activity.status === "unknown" && activityLoaded ? (
+                          <Badge variant="warning">Could not check cache activity</Badge>
+                        ) : null}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <span>Watching since {formatDate(watch.watchedAt)}</span>
+                        <span>·</span>
+                        <span>Last visited {formatDate(watch.lastVisitedAt)}</span>
+                        {activity.cachedAt ? (
+                          <>
+                            <span>·</span>
+                            <span>
+                              {activity.status === "updated" ? "Fresh cache activity" : "Latest cache"}{" "}
+                              {cachedFreshness ?? formatDate(activity.cachedAt)}
+                            </span>
+                          </>
+                        ) : activity.status === "missing" && activityLoaded ? (
+                          <>
+                            <span>·</span>
+                            <span>No cached snapshot yet</span>
+                          </>
+                        ) : activity.status === "unknown" && activityLoaded ? (
+                          <>
+                            <span>·</span>
+                            <span>Could not check cache activity right now</span>
+                          </>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <Link
+                        href={`/${watch.owner}/${watch.repo}`}
+                        className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
+                      >
+                        Open
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(watch.fullName)}
+                        className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
+                        aria-label={`Stop watching ${watch.fullName}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
                   </div>
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <Link
-                    href={`/${watch.owner}/${watch.repo}`}
-                    className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
-                  >
-                    Open
-                    <ArrowRight className="h-3.5 w-3.5" />
-                  </Link>
-                  <button
-                    type="button"
-                    onClick={() => handleRemove(watch.fullName)}
-                    className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
-                    aria-label={`Stop watching ${watch.fullName}`}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
+                )
+              })}
+            </div>
+          </>
         )}
       </section>
     </RepoShell>

--- a/web/src/lib/server/reports.ts
+++ b/web/src/lib/server/reports.ts
@@ -87,6 +87,40 @@ export async function getRepoRecord(fullName: string): Promise<StoredReportRecor
   return rows[0] ?? null
 }
 
+export async function getRepoCacheActivities(
+  fullNames: string[],
+): Promise<Record<string, { status: "cached" | "missing"; cachedAt: string | null }>> {
+  if (fullNames.length === 0) {
+    return {}
+  }
+
+  const rows = await query<Pick<StoredReportRecord, "full_name" | "status" | "cached_at">>(
+    `select full_name, status, cached_at
+    from repo_reports
+    where full_name = any($1::text[])`,
+    [fullNames],
+  )
+
+  const activities: Record<string, { status: "cached" | "missing"; cachedAt: string | null }> = Object.fromEntries(
+    fullNames.map((fullName) => [
+      fullName,
+      {
+        status: "missing" as const,
+        cachedAt: null,
+      },
+    ]),
+  )
+
+  for (const row of rows) {
+    activities[row.full_name] = {
+      status: row.cached_at ? "cached" : "missing",
+      cachedAt: row.cached_at ?? null,
+    }
+  }
+
+  return activities
+}
+
 export async function touchQueuedRepo(owner: string, repo: string, queuedNow: boolean): Promise<void> {
   const fullName = `${owner}/${repo}`
   const githubUrl = `https://github.com/${fullName}`

--- a/web/src/lib/watches.ts
+++ b/web/src/lib/watches.ts
@@ -8,6 +8,19 @@ export type WatchEntry = {
   lastVisitedAt: string
 }
 
+export type WatchActivitySource = {
+  status: "cached" | "missing" | "unknown"
+  cachedAt: string | null
+}
+
+export type WatchActivity = {
+  status: "updated" | "cached" | "missing" | "unknown"
+  cachedAt: string | null
+  hasUpdate: boolean
+}
+
+export const WATCH_ACTIVITY_BATCH_SIZE = 100
+
 const WATCHES_STORAGE_KEY = "discofork-watches"
 
 const store = createArrayStore<WatchEntry>({
@@ -39,8 +52,95 @@ export function touchWatch(fullName: string): void {
   }
 }
 
-export function hasUpdate(watch: WatchEntry, cachedAt: string): boolean {
-  const watchedDate = new Date(watch.lastVisitedAt)
-  const cachedDate = new Date(cachedAt)
-  return cachedDate > watchedDate
+function toTimestamp(value: string | null | undefined): number | null {
+  if (!value) {
+    return null
+  }
+
+  const timestamp = new Date(value).getTime()
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
+export function hasUpdate(watch: WatchEntry, cachedAt: string | null | undefined): boolean {
+  const visitedTimestamp = toTimestamp(watch.lastVisitedAt)
+  const cachedTimestamp = toTimestamp(cachedAt)
+
+  if (visitedTimestamp === null || cachedTimestamp === null) {
+    return false
+  }
+
+  return cachedTimestamp > visitedTimestamp
+}
+
+export function getWatchActivity(
+  watch: WatchEntry,
+  source: WatchActivitySource | null | undefined,
+): WatchActivity {
+  if (!source || source.status === "unknown") {
+    return {
+      status: "unknown",
+      cachedAt: null,
+      hasUpdate: false,
+    }
+  }
+
+  if (source.status === "missing") {
+    return {
+      status: "missing",
+      cachedAt: null,
+      hasUpdate: false,
+    }
+  }
+
+  const cachedAt = source.cachedAt ?? null
+  const updated = hasUpdate(watch, cachedAt)
+
+  return {
+    status: updated ? "updated" : "cached",
+    cachedAt,
+    hasUpdate: updated,
+  }
+}
+
+export function chunkWatchFullNames(
+  fullNames: string[],
+  chunkSize = WATCH_ACTIVITY_BATCH_SIZE,
+): string[][] {
+  if (chunkSize < 1) {
+    return [fullNames]
+  }
+
+  const chunks: string[][] = []
+  for (let index = 0; index < fullNames.length; index += chunkSize) {
+    chunks.push(fullNames.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+export function sortWatchesByActivity(
+  watches: WatchEntry[],
+  activityByFullName: Record<string, WatchActivitySource | null | undefined> = {},
+): WatchEntry[] {
+  return watches
+    .map((watch, index) => {
+      const activity = getWatchActivity(watch, activityByFullName[watch.fullName])
+      return {
+        watch,
+        index,
+        activity,
+        cachedTimestamp: toTimestamp(activity.cachedAt),
+      }
+    })
+    .sort((left, right) => {
+      if (left.activity.hasUpdate !== right.activity.hasUpdate) {
+        return left.activity.hasUpdate ? -1 : 1
+      }
+
+      if (left.activity.hasUpdate && right.activity.hasUpdate && left.cachedTimestamp !== right.cachedTimestamp) {
+        return (right.cachedTimestamp ?? 0) - (left.cachedTimestamp ?? 0)
+      }
+
+      return left.index - right.index
+    })
+    .map(({ watch }) => watch)
 }


### PR DESCRIPTION
Closes #111

## Summary
- add watched-page helpers for cache activity state, batching, and updated-first ordering
- add a read-only batched `/api/watched/activity` route so `/watched` can inspect cache freshness without queueing repos
- surface Updated / Cached / Missing / Unknown states directly on watched rows and cover the helper logic with Bun tests

## Why this improves Discofork
The watched page already promised update badges, but it never loaded cache freshness data. This change makes `/watched` actually answer "what changed since I last looked?" while keeping the behavior local-first and avoiding side effects that would queue watched repos just from opening the page.

## Validation
- `npx bun test test/watches.test.ts`
- `cd web && npx bun run typecheck`
- `cd web && npx bun run build`

## Review
- Used reviewer-only fallback for the pre-commit review gate because the full `review-changes` orchestration path was unavailable in this execution context.
- Fixed review findings by switching watched activity checks to a dedicated read-only route, batching large watch lists, using POST payloads instead of long query strings, and preserving cached activity when a repo has a previous snapshot but is temporarily re-queued.

## Risks / follow-ups
- The watched page now makes batched best-effort activity checks; failed batches intentionally render an explicit unknown-state badge instead of pretending a repo has no snapshot.
- A follow-up integration test for the watched activity route and partial batch-failure path would be nice, but the core helper logic is covered in this PR.

## Exec plan
- `.hermes/plans/2026-04-15-watched-cache-activity.md`
