### PR TITLE
feat(web): add discover card quick actions

### DIFF
--- a/test/local-client-repo-actions.test.ts
+++ b/test/local-client-repo-actions.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+import {
+  BOOKMARKS_CHANGE_EVENT,
+  getBookmarks,
+  isBookmarked,
+  toggleBookmark,
+} from "../web/src/lib/bookmarks"
+import {
+  WATCHES_CHANGE_EVENT,
+  getWatches,
+  isWatched,
+  toggleWatch,
+  touchWatch,
+} from "../web/src/lib/watches"
+
+type MockStorage = {
+  clear: () => void
+  getItem: (key: string) => string | null
+  removeItem: (key: string) => void
+  setItem: (key: string, value: string) => void
+}
+
+function createMockStorage(): MockStorage {
+  const store = new Map<string, string>()
+
+  return {
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    removeItem: (key) => {
+      store.delete(key)
+    },
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+  }
+}
+
+function installMockWindow() {
+  const localStorage = createMockStorage()
+  const mockWindow = Object.assign(new EventTarget(), { localStorage })
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: mockWindow,
+    writable: true,
+  })
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorage,
+    writable: true,
+  })
+
+  return { localStorage, mockWindow }
+}
+
+describe("local client repo action stores", () => {
+  beforeEach(() => {
+    installMockWindow()
+  })
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).window
+    delete (globalThis as Record<string, unknown>).localStorage
+  })
+
+  test("bookmark toggles emit a same-page change event", () => {
+    const bookmarkEvents: string[][] = []
+
+    window.addEventListener(BOOKMARKS_CHANGE_EVENT, () => {
+      bookmarkEvents.push(getBookmarks().map((entry) => entry.fullName))
+    })
+
+    expect(isBookmarked("openai/codex")).toBe(false)
+    expect(toggleBookmark("openai", "codex")).toBe(true)
+    expect(isBookmarked("openai/codex")).toBe(true)
+    expect(bookmarkEvents).toEqual([["openai/codex"]])
+
+    expect(toggleBookmark("openai", "codex")).toBe(false)
+    expect(isBookmarked("openai/codex")).toBe(false)
+    expect(bookmarkEvents).toEqual([["openai/codex"], []])
+  })
+
+  test("watch toggles and touch updates emit same-page change events", async () => {
+    const watchEventCounts: number[] = []
+
+    window.addEventListener(WATCHES_CHANGE_EVENT, () => {
+      watchEventCounts.push(getWatches().length)
+    })
+
+    expect(isWatched("schema-labs-ltd/discofork")).toBe(false)
+    expect(toggleWatch("schema-labs-ltd", "discofork")).toBe(true)
+    expect(isWatched("schema-labs-ltd/discofork")).toBe(true)
+
+    const watchedBeforeTouch = getWatches()[0]
+    await Bun.sleep(5)
+    touchWatch("schema-labs-ltd/discofork")
+    const watchedAfterTouch = getWatches()[0]
+
+    expect(new Date(watchedAfterTouch.lastVisitedAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(watchedBeforeTouch.lastVisitedAt).getTime(),
+    )
+    expect(watchEventCounts).toEqual([1, 1])
+  })
+})

--- a/web/src/app/discover/page.tsx
+++ b/web/src/app/discover/page.tsx
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useState } from "react"
 import Link from "next/link"
 import { ArrowRight, Calendar, Clock, GitFork, Shuffle, Star } from "lucide-react"
 
+import { BookmarkButton } from "@/components/bookmark-button"
+import { CompareToggle } from "@/components/compare-toggle"
 import { RepoShell } from "@/components/repo-shell"
+import { WatchButton } from "@/components/watch-button"
 import { Badge } from "@/components/ui/badge"
 import type { RepoListItem, RepoListView } from "@/lib/repository-list"
 
@@ -35,11 +38,11 @@ function shuffleArray<T>(items: T[]): T[] {
 
 function DiscoverCard({ item }: { item: RepoListItem }) {
   return (
-    <Link
-      href={`/${item.owner}/${item.repo}`}
-      className="group block rounded-[1.25rem] border border-border bg-card/70 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.28)] transition-colors hover:border-primary/40"
-    >
-      <div className="space-y-3">
+    <div className="group rounded-[1.25rem] border border-border bg-card/70 shadow-[0_24px_80px_rgba(0,0,0,0.28)] transition-colors hover:border-primary/40">
+      <Link
+        href={`/${item.owner}/${item.repo}`}
+        className="block space-y-3 px-4 py-5 sm:px-5"
+      >
         <div className="flex items-start justify-between gap-2">
           <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">
             {item.fullName}
@@ -64,8 +67,23 @@ function DiscoverCard({ item }: { item: RepoListItem }) {
             {formatDate(item.lastPushedAt)}
           </Badge>
         </div>
+      </Link>
+
+      <div className="flex flex-col gap-3 border-t border-border/70 px-4 pb-5 pt-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+        <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          Triage in place
+        </span>
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label={`${item.fullName} quick actions`}
+        >
+          <CompareToggle fullName={item.fullName} showLabel compact />
+          <BookmarkButton owner={item.owner} repo={item.repo} variant="button" compact />
+          <WatchButton owner={item.owner} repo={item.repo} variant="button" compact />
+        </div>
       </div>
-    </Link>
+    </div>
   )
 }
 

--- a/web/src/components/bookmark-button.tsx
+++ b/web/src/components/bookmark-button.tsx
@@ -4,17 +4,19 @@ import { useCallback, useEffect, useState } from "react"
 import { Bookmark, BookmarkCheck } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { BOOKMARKS_CHANGE_EVENT, isBookmarked, toggleBookmark } from "@/lib/bookmarks"
 import { cn } from "@/lib/utils"
-import { isBookmarked, toggleBookmark } from "@/lib/bookmarks"
 
 export function BookmarkButton({
   owner,
   repo,
   variant = "icon",
+  compact = false,
 }: {
   owner: string
   repo: string
   variant?: "icon" | "button"
+  compact?: boolean
 }) {
   const [bookmarked, setBookmarked] = useState(false)
   const [mounted, setMounted] = useState(false)
@@ -22,18 +24,39 @@ export function BookmarkButton({
 
   useEffect(() => {
     setMounted(true)
-    setBookmarked(isBookmarked(fullName))
+
+    const sync = () => {
+      setBookmarked(isBookmarked(fullName))
+    }
+
+    sync()
+    window.addEventListener("storage", sync)
+    window.addEventListener(BOOKMARKS_CHANGE_EVENT, sync as EventListener)
+
+    return () => {
+      window.removeEventListener("storage", sync)
+      window.removeEventListener(BOOKMARKS_CHANGE_EVENT, sync as EventListener)
+    }
   }, [fullName])
 
-  const handleToggle = useCallback(() => {
+  const handleToggle = useCallback((event?: React.MouseEvent<HTMLButtonElement>) => {
+    event?.preventDefault()
+    event?.stopPropagation()
+
     const next = toggleBookmark(owner, repo)
     setBookmarked(next)
   }, [owner, repo])
 
+  const buttonClassName = cn(
+    "gap-2",
+    compact ? "h-8 rounded-full px-3 text-xs" : "rounded-md px-4",
+    bookmarked && "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  )
+
   if (!mounted) {
     if (variant === "button") {
       return (
-        <Button variant="outline" className="gap-2 rounded-md px-4" disabled>
+        <Button type="button" variant="outline" className={buttonClassName} disabled>
           <Bookmark className="h-4 w-4" />
           Bookmark
         </Button>
@@ -45,6 +68,7 @@ export function BookmarkButton({
         disabled
         className="rounded-md p-2 text-muted-foreground opacity-50"
         aria-label="Bookmark"
+        aria-pressed={false}
       >
         <Bookmark className="h-4 w-4" />
       </button>
@@ -54,12 +78,11 @@ export function BookmarkButton({
   if (variant === "button") {
     return (
       <Button
+        type="button"
         variant="outline"
         onClick={handleToggle}
-        className={cn(
-          "gap-2 rounded-md px-4",
-          bookmarked && "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-        )}
+        className={buttonClassName}
+        aria-pressed={bookmarked}
       >
         {bookmarked ? <BookmarkCheck className="h-4 w-4" /> : <Bookmark className="h-4 w-4" />}
         {bookmarked ? "Bookmarked" : "Bookmark"}
@@ -78,6 +101,7 @@ export function BookmarkButton({
           : "text-muted-foreground hover:text-foreground",
       )}
       aria-label={bookmarked ? "Remove bookmark" : "Add bookmark"}
+      aria-pressed={bookmarked}
     >
       {bookmarked ? <BookmarkCheck className="h-4 w-4" /> : <Bookmark className="h-4 w-4" />}
     </button>

--- a/web/src/components/compare-toggle.tsx
+++ b/web/src/components/compare-toggle.tsx
@@ -22,9 +22,11 @@ function syncCompareSelection(
 export function CompareToggle({
   fullName,
   showLabel = false,
+  compact = false,
 }: {
   fullName: string
   showLabel?: boolean
+  compact?: boolean
 }) {
   const [selected, setSelected] = useState(false)
   const [repos, setRepos] = useState<string[]>([])
@@ -51,7 +53,7 @@ export function CompareToggle({
   const atCapacity = repos.length >= MAX_COMPARE_REPOS && !selected
 
   const handleToggle = useCallback(
-    (e: React.MouseEvent) => {
+    (e: React.MouseEvent<HTMLButtonElement>) => {
       e.preventDefault()
       e.stopPropagation()
 
@@ -66,15 +68,27 @@ export function CompareToggle({
     [atCapacity, fullName],
   )
 
+  const compactButtonClassName = cn(
+    "inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors",
+    atCapacity && !selected && "cursor-not-allowed opacity-50",
+    selected
+      ? "border-primary/20 bg-primary/10 text-primary hover:bg-primary/20"
+      : "border-border bg-background/80 text-muted-foreground hover:bg-accent hover:text-foreground",
+  )
+
   if (!mounted) {
     return (
       <button
         type="button"
         disabled
-        className="rounded-md p-1.5 text-muted-foreground opacity-50"
+        className={compact || showLabel
+          ? "inline-flex h-8 items-center gap-1.5 rounded-full border border-border bg-background/70 px-3 text-xs text-muted-foreground opacity-50"
+          : "rounded-md p-1.5 text-muted-foreground opacity-50"}
         aria-label="Add to compare"
+        aria-pressed={false}
       >
         <GitCompareArrows className="h-3.5 w-3.5" />
+        {compact || showLabel ? <span>{compact ? "Compare" : "Add"}</span> : null}
       </button>
     )
   }
@@ -84,18 +98,23 @@ export function CompareToggle({
       type="button"
       onClick={handleToggle}
       aria-disabled={atCapacity}
-      className={cn(
-        "flex items-center gap-1.5 rounded-md p-1.5 transition-colors",
-        atCapacity && !selected && "cursor-not-allowed opacity-50",
-        selected
-          ? "bg-primary/10 text-primary hover:bg-primary/20"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground",
-      )}
+      aria-pressed={selected}
+      className={compact
+        ? compactButtonClassName
+        : cn(
+            "flex items-center gap-1.5 rounded-md p-1.5 transition-colors",
+            atCapacity && !selected && "cursor-not-allowed opacity-50",
+            selected
+              ? "bg-primary/10 text-primary hover:bg-primary/20"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground",
+          )}
       aria-label={selected ? "Remove from compare" : atCapacity ? "Compare limit reached" : "Add to compare"}
     >
       <GitCompareArrows className="h-3.5 w-3.5" />
-      {showLabel ? (
-        <span className="text-xs">{selected ? "Remove" : atCapacity ? "Limit reached" : "Compare"}</span>
+      {showLabel || compact ? (
+        <span className={compact ? undefined : "text-xs"}>
+          {selected ? (compact ? "Selected" : "Remove") : atCapacity ? "Limit reached" : "Compare"}
+        </span>
       ) : null}
     </button>
   )

--- a/web/src/components/watch-button.tsx
+++ b/web/src/components/watch-button.tsx
@@ -4,17 +4,19 @@ import { useCallback, useEffect, useState } from "react"
 import { Eye, EyeOff } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { WATCHES_CHANGE_EVENT, isWatched, toggleWatch } from "@/lib/watches"
 import { cn } from "@/lib/utils"
-import { isWatched, toggleWatch } from "@/lib/watches"
 
 export function WatchButton({
   owner,
   repo,
   variant = "icon",
+  compact = false,
 }: {
   owner: string
   repo: string
   variant?: "icon" | "button"
+  compact?: boolean
 }) {
   const [watched, setWatched] = useState(false)
   const [mounted, setMounted] = useState(false)
@@ -22,18 +24,39 @@ export function WatchButton({
 
   useEffect(() => {
     setMounted(true)
-    setWatched(isWatched(fullName))
+
+    const sync = () => {
+      setWatched(isWatched(fullName))
+    }
+
+    sync()
+    window.addEventListener("storage", sync)
+    window.addEventListener(WATCHES_CHANGE_EVENT, sync as EventListener)
+
+    return () => {
+      window.removeEventListener("storage", sync)
+      window.removeEventListener(WATCHES_CHANGE_EVENT, sync as EventListener)
+    }
   }, [fullName])
 
-  const handleToggle = useCallback(() => {
+  const handleToggle = useCallback((event?: React.MouseEvent<HTMLButtonElement>) => {
+    event?.preventDefault()
+    event?.stopPropagation()
+
     const next = toggleWatch(owner, repo)
     setWatched(next)
   }, [owner, repo])
 
+  const buttonClassName = cn(
+    "gap-2",
+    compact ? "h-8 rounded-full px-3 text-xs" : "rounded-md px-4",
+    watched && "border-blue-500/20 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+  )
+
   if (!mounted) {
     if (variant === "button") {
       return (
-        <Button variant="outline" className="gap-2 rounded-md px-4" disabled>
+        <Button type="button" variant="outline" className={buttonClassName} disabled>
           <Eye className="h-4 w-4" />
           Watch
         </Button>
@@ -45,6 +68,7 @@ export function WatchButton({
         disabled
         className="rounded-md p-2 text-muted-foreground opacity-50"
         aria-label="Watch"
+        aria-pressed={false}
       >
         <Eye className="h-4 w-4" />
       </button>
@@ -54,12 +78,11 @@ export function WatchButton({
   if (variant === "button") {
     return (
       <Button
+        type="button"
         variant="outline"
         onClick={handleToggle}
-        className={cn(
-          "gap-2 rounded-md px-4",
-          watched && "border-blue-500/20 bg-blue-500/10 text-blue-700 dark:text-blue-300",
-        )}
+        className={buttonClassName}
+        aria-pressed={watched}
       >
         {watched ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
         {watched ? "Watching" : "Watch"}
@@ -78,6 +101,7 @@ export function WatchButton({
           : "text-muted-foreground hover:text-foreground",
       )}
       aria-label={watched ? "Unwatch" : "Watch"}
+      aria-pressed={watched}
     >
       {watched ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
     </button>

--- a/web/src/lib/bookmarks.ts
+++ b/web/src/lib/bookmarks.ts
@@ -18,8 +18,36 @@ const store = createArrayStore<BookmarkEntry>({
   }),
 })
 
+export const BOOKMARKS_CHANGE_EVENT = "discofork:bookmark-change"
+
+function emitBookmarksChange(bookmarks: BookmarkEntry[] = getBookmarks()): void {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<{ bookmarks: BookmarkEntry[] }>(BOOKMARKS_CHANGE_EVENT, {
+      detail: { bookmarks },
+    }),
+  )
+}
+
 export const getBookmarks = store.getAll
 export const isBookmarked = store.has
-export const addBookmark = store.add
-export const removeBookmark = store.remove
-export const toggleBookmark = store.toggle
+
+export function addBookmark(owner: string, repo: string): BookmarkEntry {
+  const entry = store.add(owner, repo)
+  emitBookmarksChange(getBookmarks())
+  return entry
+}
+
+export function removeBookmark(fullName: string): void {
+  store.remove(fullName)
+  emitBookmarksChange(getBookmarks())
+}
+
+export function toggleBookmark(owner: string, repo: string): boolean {
+  const next = store.toggle(owner, repo)
+  emitBookmarksChange(getBookmarks())
+  return next
+}

--- a/web/src/lib/watches.ts
+++ b/web/src/lib/watches.ts
@@ -22,11 +22,39 @@ const store = createArrayStore<WatchEntry>({
   }),
 })
 
+export const WATCHES_CHANGE_EVENT = "discofork:watch-change"
+
+function emitWatchesChange(watches: WatchEntry[] = getWatches()): void {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<{ watches: WatchEntry[] }>(WATCHES_CHANGE_EVENT, {
+      detail: { watches },
+    }),
+  )
+}
+
 export const getWatches = store.getAll
 export const isWatched = store.has
-export const addWatch = store.add
-export const removeWatch = store.remove
-export const toggleWatch = store.toggle
+
+export function addWatch(owner: string, repo: string): WatchEntry {
+  const entry = store.add(owner, repo)
+  emitWatchesChange(getWatches())
+  return entry
+}
+
+export function removeWatch(fullName: string): void {
+  store.remove(fullName)
+  emitWatchesChange(getWatches())
+}
+
+export function toggleWatch(owner: string, repo: string): boolean {
+  const next = store.toggle(owner, repo)
+  emitWatchesChange(getWatches())
+  return next
+}
 
 export function touchWatch(fullName: string): void {
   const watches = getWatches()
@@ -35,6 +63,7 @@ export function touchWatch(fullName: string): void {
     entry.lastVisitedAt = new Date().toISOString()
     if (typeof window !== "undefined") {
       localStorage.setItem(WATCHES_STORAGE_KEY, JSON.stringify(watches))
+      emitWatchesChange(watches)
     }
   }
 }


### PR DESCRIPTION
Closes #110

## Summary
- add bookmark, watch, and compare quick actions directly to discovery cards
- keep discover-card navigation separate from the inline action row so card browsing stays intact
- sync bookmark/watch state across duplicate cards on the same page and add focused local-store regression coverage

## Validation
- `npx bun test test/local-client-repo-actions.test.ts`
- `cd web && npx bun run typecheck`
- `cd web && npx bun run build`
- `git diff --check`

## Review
- Used the `review-changes` fallback reviewer-only path against a canonical local diff packet because the full parallel orchestration path was not practical in this environment.
- Initial review flagged nested interactive controls inside the card link; the card was refactored so navigation and quick actions are sibling regions, then validation and review were rerun.
