### PR TITLE
feat(compare): accept pasted repo names and URLs

### DIFF
--- a/test/compare-selection.test.ts
+++ b/test/compare-selection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test"
 import {
   MAX_COMPARE_REPOS,
   addCompareSelectionRepo,
+  applyCompareRepoInput,
   normalizeCompareSelection,
   parseCompareSelectionValue,
   removeCompareSelectionRepo,
@@ -54,5 +55,55 @@ describe("compare selection helpers", () => {
     expect(replaceCompareSelectionRepo(["a/b", "c/d", "e/f"], "c/d", "a/b")).toEqual(["a/b", "e/f"])
     expect(replaceCompareSelectionRepo(["a/b", "c/d"], null, "e/f")).toEqual(["a/b", "c/d", "e/f"])
     expect(replaceCompareSelectionRepo(["a/b", "c/d", "e/f"], null, "g/h")).toEqual(["a/b", "c/d", "e/f"])
+  })
+
+  test("applyCompareRepoInput adds owner repo input to the next open slot", () => {
+    expect(applyCompareRepoInput(["schema-labs-ltd/discofork"], "openai/codex")).toEqual({
+      kind: "added",
+      fullName: "openai/codex",
+      message: "Added openai/codex to compare. Cached comparison data will appear here when available.",
+      nextSelection: ["schema-labs-ltd/discofork", "openai/codex"],
+    })
+  })
+
+  test("applyCompareRepoInput normalizes GitHub and Discofork URLs into the same compare selection", () => {
+    expect(applyCompareRepoInput([], "https://github.com/openai/codex").nextSelection).toEqual(["openai/codex"])
+    expect(applyCompareRepoInput([], "https://discofork.ai/openai/codex").nextSelection).toEqual(["openai/codex"])
+  })
+
+  test("applyCompareRepoInput replaces the selected slot when compare is full", () => {
+    expect(applyCompareRepoInput(["a/b", "c/d", "e/f"], "https://github.com/openai/codex", "c/d")).toEqual({
+      kind: "replaced",
+      fullName: "openai/codex",
+      message: "Replaced c/d with openai/codex. Cached comparison data will appear here when available.",
+      nextSelection: ["a/b", "openai/codex", "e/f"],
+    })
+  })
+
+  test("applyCompareRepoInput ignores stale replace targets that are no longer selected", () => {
+    expect(applyCompareRepoInput(["a/b", "c/d", "e/f"], "openai/codex", "missing/repo")).toEqual({
+      kind: "error",
+      fullName: null,
+      message: "Compare is full. Click Replace on a selected repo, then paste a repository here.",
+      nextSelection: ["a/b", "c/d", "e/f"],
+    })
+  })
+
+  test("applyCompareRepoInput does not replace a slot with a repo that is already selected elsewhere", () => {
+    expect(applyCompareRepoInput(["a/b", "c/d", "e/f"], "a/b", "c/d")).toEqual({
+      kind: "unchanged",
+      fullName: "a/b",
+      message: "a/b is already selected in another compare slot.",
+      nextSelection: ["a/b", "c/d", "e/f"],
+    })
+  })
+
+  test("applyCompareRepoInput requires a replace target when compare is already full", () => {
+    expect(applyCompareRepoInput(["a/b", "c/d", "e/f"], "openai/codex")).toEqual({
+      kind: "error",
+      fullName: null,
+      message: "Compare is full. Click Replace on a selected repo, then paste a repository here.",
+      nextSelection: ["a/b", "c/d", "e/f"],
+    })
   })
 })

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Suspense, useEffect, useMemo, useState } from "react"
+import { Suspense, useEffect, useMemo, useState, type FormEvent } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import { ArrowRight, Download, GitCompareArrows, Plus, RefreshCcw, Trash2, X } from "lucide-react"
@@ -10,12 +10,11 @@ import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
 import {
   MAX_COMPARE_REPOS,
-  addCompareSelectionRepo,
+  applyCompareRepoInput,
   buildCompareHref,
   getCompareSelection,
   parseCompareSelectionValue,
   removeCompareSelectionRepo,
-  replaceCompareSelectionRepo,
   setCompareSelection,
 } from "@/lib/compare"
 import { exportComparison } from "@/lib/export-comparison"
@@ -197,7 +196,7 @@ function EmptyCompareSlot() {
       <div className="space-y-1">
         <div className="text-sm font-semibold text-foreground">Open compare slot</div>
         <p className="text-xs leading-5 text-muted-foreground">
-          Add a recent, bookmarked, or watched repository below.
+          Paste a repo above or add a recent, bookmarked, or watched repository below.
         </p>
       </div>
     </div>
@@ -250,6 +249,8 @@ function CompareContent() {
   const [repoViews, setRepoViews] = useState<Record<string, CachedRepoView>>({})
   const [suggestions, setSuggestions] = useState<RepoLauncherSuggestion[]>([])
   const [replaceTarget, setReplaceTarget] = useState<string | null>(null)
+  const [manualInput, setManualInput] = useState("")
+  const [manualFeedback, setManualFeedback] = useState<{ message: string; tone: "error" | "info" | "success" } | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -268,6 +269,13 @@ function CompareContent() {
       router.replace(buildCompareHref(nextSelection), { scroll: false })
     }
   }, [router, searchParams])
+
+  useEffect(() => {
+    if (replaceTarget && !selection.includes(replaceTarget)) {
+      setReplaceTarget(null)
+      setManualFeedback(null)
+    }
+  }, [replaceTarget, selection])
 
   useEffect(() => {
     let cancelled = false
@@ -331,10 +339,16 @@ function CompareContent() {
 
   const compareLimitReached = selection.length >= MAX_COMPARE_REPOS
   const instruction = replaceTarget
-    ? `Replacing ${replaceTarget}. Pick one of the suggestions below to swap it out in place.`
+    ? `Replacing ${replaceTarget}. Paste a repo above or pick one of the suggestions below to swap it out in place.`
     : compareLimitReached
-      ? "You have reached the 3-repo compare limit. Click Replace on a selected repo, then choose a suggestion below."
-      : `Add up to ${MAX_COMPARE_REPOS - selection.length} more repositories from your recent, bookmarked, or watched activity.`
+      ? "You have reached the 3-repo compare limit. Click Replace on a selected repo, then paste a repo above or choose a suggestion below."
+      : `Paste a repo above or add up to ${MAX_COMPARE_REPOS - selection.length} more repositories from your recent, bookmarked, or watched activity.`
+  const pasteInstruction = replaceTarget
+    ? `Paste an owner/repo value or a GitHub or Discofork URL to replace ${replaceTarget}.`
+    : compareLimitReached
+      ? "Choose Replace on a selected repo, then paste an owner/repo value or repo URL here."
+      : "Paste an owner/repo value or a GitHub or Discofork URL to fill the next open compare slot."
+  const pasteActionLabel = replaceTarget ? `Replace ${replaceTarget}` : "Add to compare"
 
   const persistWorkspace = (nextSelection: string[]) => {
     const persistedSelection = setCompareSelection(nextSelection)
@@ -344,19 +358,56 @@ function CompareContent() {
   }
 
   const handleRemove = (fullName: string) => {
+    setManualFeedback(null)
+    if (replaceTarget === fullName) {
+      setReplaceTarget(null)
+    }
     persistWorkspace(removeCompareSelectionRepo(selection, fullName))
   }
 
   const handleClear = () => {
+    setManualFeedback(null)
+    setManualInput("")
+    setReplaceTarget(null)
     persistWorkspace([])
   }
 
   const handleSuggestionAction = (suggestion: RepoLauncherSuggestion) => {
-    const nextSelection = replaceTarget
-      ? replaceCompareSelectionRepo(selection, replaceTarget, suggestion.fullName)
-      : addCompareSelectionRepo(selection, suggestion.fullName)
+    const result = applyCompareRepoInput(selection, suggestion.fullName, replaceTarget)
 
-    persistWorkspace(nextSelection)
+    if (result.kind === "error") {
+      setManualFeedback({ message: result.message, tone: "error" })
+      return
+    }
+
+    if (result.kind === "unchanged") {
+      setManualFeedback({ message: result.message, tone: "info" })
+      return
+    }
+
+    persistWorkspace(result.nextSelection)
+    setManualInput("")
+    setManualFeedback({ message: result.message, tone: "success" })
+    setReplaceTarget(null)
+  }
+
+  const handleManualSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const result = applyCompareRepoInput(selection, manualInput, replaceTarget)
+    if (result.kind === "error") {
+      setManualFeedback({ message: result.message, tone: "error" })
+      return
+    }
+
+    if (result.kind === "unchanged") {
+      setManualFeedback({ message: result.message, tone: "info" })
+      return
+    }
+
+    persistWorkspace(result.nextSelection)
+    setManualInput("")
+    setManualFeedback({ message: result.message, tone: "success" })
     setReplaceTarget(null)
   }
 
@@ -385,6 +436,46 @@ function CompareContent() {
           ) : null}
         </div>
 
+        <div className="rounded-md border border-dashed border-border bg-background/40 p-4">
+          <div className="space-y-1">
+            <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Paste a repo</div>
+            <h3 className="text-sm font-semibold text-foreground">Add directly from a name or URL</h3>
+            <p className="text-xs leading-5 text-muted-foreground">{pasteInstruction}</p>
+          </div>
+          <form onSubmit={handleManualSubmit} className="mt-4 space-y-3">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <input
+                type="text"
+                value={manualInput}
+                onChange={(event) => {
+                  setManualInput(event.target.value)
+                  setManualFeedback(null)
+                }}
+                placeholder="openai/codex or https://github.com/openai/codex"
+                className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+              />
+              <Button type="submit" className="gap-2 sm:self-start">
+                {pasteActionLabel}
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+            </div>
+            {manualFeedback ? (
+              <div
+                className={cn(
+                  "rounded-md border px-3 py-2 text-sm",
+                  manualFeedback.tone === "error"
+                    ? "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300"
+                    : manualFeedback.tone === "info"
+                      ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200"
+                      : "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+                )}
+              >
+                {manualFeedback.message}
+              </div>
+            ) : null}
+          </form>
+        </div>
+
         <div className="grid gap-4 lg:grid-cols-3">
           {selection.map((fullName) => (
             <ComparePickCard
@@ -393,7 +484,10 @@ function CompareContent() {
               view={repoViews[fullName]}
               replacing={replaceTarget === fullName}
               onRemove={handleRemove}
-              onToggleReplace={(target) => setReplaceTarget((current) => (current === target ? null : target))}
+              onToggleReplace={(target) => {
+                setManualFeedback(null)
+                setReplaceTarget((current) => (current === target ? null : target))
+              }}
             />
           ))}
           {Array.from({ length: Math.max(MAX_COMPARE_REPOS - selection.length, 0) }).map((_, index) => (
@@ -442,7 +536,7 @@ function CompareContent() {
             <div className="space-y-3">
               <h2 className="text-base font-semibold text-foreground">No local compare suggestions yet</h2>
               <p className="text-sm leading-7 text-muted-foreground">
-                Browse the repository index to build your first compare set, then come back here to keep editing it in place.
+                Paste a repo above to build your first compare set, or browse the repository index to build more local suggestions for this browser.
               </p>
               <Link href="/repos" className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}>
                 Browse repositories
@@ -563,7 +657,7 @@ export default function ComparePage() {
     <RepoShell
       eyebrow="Repository comparison"
       title="Compare repositories side by side."
-      description="Manage your active comparison directly on this page, remove or replace selections in place, and seed new compare sets from recent, bookmarked, or watched repositories."
+      description="Manage your active comparison directly on this page, paste repositories by name or URL, remove or replace selections in place, and seed new compare sets from recent, bookmarked, or watched repositories."
       compact
     >
       <Suspense

--- a/web/src/lib/compare-selection.ts
+++ b/web/src/lib/compare-selection.ts
@@ -1,6 +1,15 @@
+import { parseRepoLauncherInput } from "./repo-launcher"
+
 export const MAX_COMPARE_REPOS = 3
 
 export type CompareSelection = string[]
+
+export type CompareRepoInputResult = {
+  kind: "added" | "error" | "replaced" | "unchanged"
+  fullName: string | null
+  message: string
+  nextSelection: CompareSelection
+}
 
 function normalizeCompareRepoName(fullName: string): string | null {
   const normalized = fullName.trim()
@@ -31,6 +40,105 @@ export function parseCompareSelectionValue(value: string | null | undefined): Co
   }
 
   return normalizeCompareSelection(value.split(","))
+}
+
+function selectionsEqual(left: CompareSelection, right: CompareSelection): boolean {
+  return left.length === right.length && left.every((repo, index) => repo === right[index])
+}
+
+export function applyCompareRepoInput(
+  repos: CompareSelection,
+  rawInput: string,
+  replaceTarget?: string | null,
+): CompareRepoInputResult {
+  const current = normalizeCompareSelection(repos)
+  const normalizedReplaceTarget = normalizeCompareRepoName(replaceTarget ?? "")
+  const activeReplaceTarget = normalizedReplaceTarget && current.includes(normalizedReplaceTarget) ? normalizedReplaceTarget : null
+  const trimmed = rawInput.trim()
+
+  if (!trimmed) {
+    return {
+      kind: "error",
+      fullName: null,
+      message: "Please enter a repository name.",
+      nextSelection: current,
+    }
+  }
+
+  const parsedRepo = parseRepoLauncherInput(trimmed)
+  if (!parsedRepo) {
+    return {
+      kind: "error",
+      fullName: null,
+      message: "Paste owner/repo, a GitHub repo URL, or a Discofork repo URL.",
+      nextSelection: current,
+    }
+  }
+
+  if (!activeReplaceTarget && current.includes(parsedRepo.fullName)) {
+    return {
+      kind: "unchanged",
+      fullName: parsedRepo.fullName,
+      message: `${parsedRepo.fullName} is already in compare.`,
+      nextSelection: current,
+    }
+  }
+
+  if (activeReplaceTarget && activeReplaceTarget !== parsedRepo.fullName && current.includes(parsedRepo.fullName)) {
+    return {
+      kind: "unchanged",
+      fullName: parsedRepo.fullName,
+      message: `${parsedRepo.fullName} is already selected in another compare slot.`,
+      nextSelection: current,
+    }
+  }
+
+  if (!activeReplaceTarget && current.length >= MAX_COMPARE_REPOS) {
+    return {
+      kind: "error",
+      fullName: null,
+      message: "Compare is full. Click Replace on a selected repo, then paste a repository here.",
+      nextSelection: current,
+    }
+  }
+
+  if (activeReplaceTarget === parsedRepo.fullName) {
+    return {
+      kind: "unchanged",
+      fullName: parsedRepo.fullName,
+      message: `${parsedRepo.fullName} is already selected in that slot.`,
+      nextSelection: current,
+    }
+  }
+
+  const nextSelection = activeReplaceTarget
+    ? replaceCompareSelectionRepo(current, activeReplaceTarget, parsedRepo.fullName)
+    : addCompareSelectionRepo(current, parsedRepo.fullName)
+
+  if (selectionsEqual(current, nextSelection)) {
+    return {
+      kind: "unchanged",
+      fullName: parsedRepo.fullName,
+      message: `${parsedRepo.fullName} is already in compare.`,
+      nextSelection: current,
+    }
+  }
+
+  if (activeReplaceTarget) {
+    return {
+      kind: "replaced",
+      fullName: parsedRepo.fullName,
+      message: `Replaced ${activeReplaceTarget} with ${parsedRepo.fullName}. Cached comparison data will appear here when available.`,
+      nextSelection,
+    }
+  }
+
+  return {
+    kind: "added",
+    fullName: parsedRepo.fullName,
+    message: `Added ${parsedRepo.fullName} to compare. Cached comparison data will appear here when available.`,
+    nextSelection,
+  }
 }
 
 export function addCompareSelectionRepo(repos: CompareSelection, fullName: string): CompareSelection {

--- a/web/src/lib/compare.ts
+++ b/web/src/lib/compare.ts
@@ -1,10 +1,12 @@
 import {
   MAX_COMPARE_REPOS,
   addCompareSelectionRepo,
+  applyCompareRepoInput,
   normalizeCompareSelection,
   parseCompareSelectionValue,
   removeCompareSelectionRepo,
   replaceCompareSelectionRepo,
+  type CompareRepoInputResult,
   type CompareSelection,
 } from "./compare-selection"
 
@@ -13,10 +15,12 @@ const COMPARE_STORAGE_KEY = "discofork-compare"
 export {
   MAX_COMPARE_REPOS,
   addCompareSelectionRepo,
+  applyCompareRepoInput,
   normalizeCompareSelection,
   parseCompareSelectionValue,
   removeCompareSelectionRepo,
   replaceCompareSelectionRepo,
+  type CompareRepoInputResult,
   type CompareSelection,
 }
 


### PR DESCRIPTION
Closes #115

## Summary
- add a compare-page paste input that accepts `owner/repo`, GitHub repo URLs, and Discofork repo URLs
- route both manual paste and local suggestion actions through the same `applyCompareRepoInput` helper so add/replace/full-capacity rules stay consistent
- add regression coverage for add, replace, duplicate, stale replace-target, and full-compare edge cases

## Why
The compare workspace previously depended on recent, bookmarked, or watched repos in local browser state. This change gives first-time visitors and ad hoc comparisons a direct way to seed or replace compare slots from the same screen.

## Validation
- `npx bun test test/compare-selection.test.ts test/repo-launcher.test.ts`
- `cd web && npx bun run typecheck`
- `cd web && npx bun run build`
- `git diff --check`

## Review
- reviewer-only fallback used for the pre-commit review gate because the full `review-changes` orchestration path was unavailable in this controller context
- reviewer feedback was applied around stale replace targets, duplicate replacement handling, and replace-state cleanup

## Risks / follow-ups
- compare-page interaction coverage is still helper-heavy; a future UI-level interaction test for the manual paste form would be a useful follow-up
- local exec plan artifact: `.hermes/plans/2026-04-15-compare-paste-repo-input.md`
