### PR TITLE
feat(tags): add saved tags page

### DIFF
--- a/test/tags-page.test.ts
+++ b/test/tags-page.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+import {
+  addTag,
+  getAllTags,
+  getRepoTags,
+  getReposByTag,
+  getTagSummaries,
+  getTagSummary,
+  removeTag,
+  setRepoTags,
+  TAGS_CHANGE_EVENT,
+  type TagsMap,
+} from "../web/src/lib/tags"
+
+type MockStorage = {
+  clear: () => void
+  getItem: (key: string) => string | null
+  removeItem: (key: string) => void
+  setItem: (key: string, value: string) => void
+}
+
+function createMockStorage(): MockStorage {
+  const store = new Map<string, string>()
+
+  return {
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    removeItem: (key) => {
+      store.delete(key)
+    },
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+  }
+}
+
+function installMockWindow() {
+  const localStorage = createMockStorage()
+  const mockWindow = Object.assign(new EventTarget(), { localStorage })
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: mockWindow,
+    writable: true,
+  })
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorage,
+    writable: true,
+  })
+
+  return { localStorage, mockWindow }
+}
+
+const SAMPLE_TAGS: TagsMap = {
+  "schema-labs-ltd/discofork": ["bug", "ops"],
+  "openai/codex": ["ai", "bug"],
+  "vercel/next.js": ["frontend", "ops"],
+}
+
+describe("tags page helpers", () => {
+  beforeEach(() => {
+    installMockWindow()
+  })
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).window
+    delete (globalThis as Record<string, unknown>).localStorage
+  })
+
+  test("getTagSummaries returns alphabetical tags with repository counts and sorted repositories", () => {
+    expect(getTagSummaries(SAMPLE_TAGS)).toEqual([
+      { tag: "ai", repoCount: 1, repos: ["openai/codex"] },
+      {
+        tag: "bug",
+        repoCount: 2,
+        repos: ["openai/codex", "schema-labs-ltd/discofork"],
+      },
+      { tag: "frontend", repoCount: 1, repos: ["vercel/next.js"] },
+      {
+        tag: "ops",
+        repoCount: 2,
+        repos: ["schema-labs-ltd/discofork", "vercel/next.js"],
+      },
+    ])
+  })
+
+  test("switching and clearing the selected tag updates the visible repositories without losing saved tags", () => {
+    let selectedTag: string | null = null
+
+    expect(getTagSummary(selectedTag, SAMPLE_TAGS)).toBeNull()
+
+    selectedTag = "bug"
+    expect(getTagSummary(selectedTag, SAMPLE_TAGS)).toEqual({
+      tag: "bug",
+      repoCount: 2,
+      repos: ["openai/codex", "schema-labs-ltd/discofork"],
+    })
+
+    selectedTag = "ops"
+    expect(getTagSummary(selectedTag, SAMPLE_TAGS)).toEqual({
+      tag: "ops",
+      repoCount: 2,
+      repos: ["schema-labs-ltd/discofork", "vercel/next.js"],
+    })
+
+    selectedTag = null
+    expect(getTagSummary(selectedTag, SAMPLE_TAGS)).toBeNull()
+    expect(getTagSummaries(SAMPLE_TAGS).map((summary) => `${summary.tag}:${summary.repoCount}`)).toEqual([
+      "ai:1",
+      "bug:2",
+      "frontend:1",
+      "ops:2",
+    ])
+  })
+
+  test("existing tag add/remove behavior remains normalized, emits change events, and stays compatible with repo filtering", () => {
+    const tagEventSnapshots: string[][] = []
+
+    window.addEventListener(TAGS_CHANGE_EVENT, () => {
+      tagEventSnapshots.push(getAllTags())
+    })
+
+    expect(getRepoTags("schema-labs-ltd/discofork")).toEqual([])
+
+    setRepoTags("schema-labs-ltd/discofork", [" Ops ", "bug", "ops", ""])
+    expect(getRepoTags("schema-labs-ltd/discofork")).toEqual(["bug", "ops"])
+
+    setRepoTags("schema-labs-ltd/discofork", ["bug", "ops"])
+    expect(tagEventSnapshots).toEqual([["bug", "ops"]])
+
+    expect(addTag("schema-labs-ltd/discofork", "BUG")).toEqual(["bug", "ops"])
+    expect(addTag("schema-labs-ltd/discofork", "release")).toEqual(["bug", "ops", "release"])
+
+    setRepoTags("openai/codex", ["bug", "ai"])
+
+    expect(getAllTags()).toEqual(["ai", "bug", "ops", "release"])
+    expect(getReposByTag("bug")).toEqual(["openai/codex", "schema-labs-ltd/discofork"])
+
+    expect(removeTag("schema-labs-ltd/discofork", "bug")).toEqual(["ops", "release"])
+    expect(removeTag("schema-labs-ltd/discofork", "ops")).toEqual(["release"])
+    expect(removeTag("schema-labs-ltd/discofork", "release")).toEqual([])
+    expect(getRepoTags("schema-labs-ltd/discofork")).toEqual([])
+    expect(getReposByTag("release")).toEqual([])
+    expect(tagEventSnapshots).toEqual([
+      ["bug", "ops"],
+      ["bug", "ops", "release"],
+      ["ai", "bug", "ops", "release"],
+      ["ai", "bug", "ops", "release"],
+      ["ai", "bug", "release"],
+      ["ai", "bug"],
+    ])
+  })
+
+  test("tags page route and shared navigation wire the new collection view into the UI", () => {
+    const pageSource = readFileSync(new URL("../web/src/app/tags/page.tsx", import.meta.url), "utf8")
+    const shellSource = readFileSync(new URL("../web/src/components/repo-shell.tsx", import.meta.url), "utf8")
+
+    expect(pageSource).toContain('eyebrow="Tags"')
+    expect(pageSource).toContain('href={`/${owner}/${repo}`}')
+    expect(pageSource).toContain("Select a tag above to view the repositories saved under it.")
+    expect(shellSource).toContain('href="/tags"')
+    expect(shellSource).toContain("Tags")
+  })
+})

--- a/web/src/app/tags/page.tsx
+++ b/web/src/app/tags/page.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { ArrowRight, Tag, X } from "lucide-react"
+
+import { RepoShell } from "@/components/repo-shell"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { getTagSummaries, TAGS_CHANGE_EVENT, TAGS_STORAGE_KEY, type TagSummary } from "@/lib/tags"
+
+function splitFullName(fullName: string) {
+  const [owner = fullName, repo = fullName] = fullName.split("/")
+  return { owner, repo }
+}
+
+export default function TagsPage() {
+  const [tagSummaries, setTagSummaries] = useState<TagSummary[]>([])
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    const syncTagSummaries = () => {
+      const summaries = getTagSummaries()
+      setTagSummaries(summaries)
+      setSelectedTag((current) => (current && summaries.some((summary) => summary.tag === current) ? current : null))
+    }
+
+    setMounted(true)
+    syncTagSummaries()
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== TAGS_STORAGE_KEY) {
+        return
+      }
+      syncTagSummaries()
+    }
+
+    window.addEventListener(TAGS_CHANGE_EVENT, syncTagSummaries)
+    window.addEventListener("storage", handleStorage)
+
+    return () => {
+      window.removeEventListener(TAGS_CHANGE_EVENT, syncTagSummaries)
+      window.removeEventListener("storage", handleStorage)
+    }
+  }, [])
+
+  const selectedSummary = useMemo(
+    () => tagSummaries.find((summary) => summary.tag === selectedTag) ?? null,
+    [selectedTag, tagSummaries],
+  )
+  const taggedRepoCount = useMemo(
+    () => new Set(tagSummaries.flatMap((summary) => summary.repos)).size,
+    [tagSummaries],
+  )
+
+  return (
+    <RepoShell
+      eyebrow="Tags"
+      title="Your saved repository tags."
+      description="Browse the tags you have saved locally, see how many repositories use each one, and reopen tagged repositories without hunting through individual repo pages."
+      compact
+    >
+      <section className="space-y-6">
+        {!mounted ? (
+          <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+            Loading saved tags...
+          </div>
+        ) : tagSummaries.length === 0 ? (
+          <div className="rounded-md border border-border bg-card p-6">
+            <div className="flex items-start gap-4">
+              <Tag className="mt-1 h-5 w-5 text-muted-foreground" />
+              <div className="space-y-3">
+                <h2 className="text-base font-semibold text-foreground">No saved tags yet</h2>
+                <p className="text-sm leading-7 text-muted-foreground">
+                  Visit any repository page and add one or more tags to organize it. Saved tags stay local to your browser and will appear here once you create them.
+                </p>
+                <Link href="/repos" className={cn(buttonVariants({ variant: "outline" }), "gap-2 rounded-md px-4")}>
+                  Browse repositories
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-4 rounded-md border border-border bg-card px-4 py-4 sm:px-5">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="space-y-1">
+                  <h2 className="text-base font-semibold text-foreground">Saved tags</h2>
+                  <p className="text-sm text-muted-foreground">
+                    {tagSummaries.length.toLocaleString()} {tagSummaries.length === 1 ? "tag" : "tags"} across {taggedRepoCount.toLocaleString()} tagged {taggedRepoCount === 1 ? "repository" : "repositories"}
+                  </p>
+                </div>
+                {selectedSummary ? (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedTag(null)}
+                    className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 rounded-md px-3 text-xs text-muted-foreground hover:text-rose-500")}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                    Clear selection
+                  </button>
+                ) : (
+                  <div className="text-xs text-muted-foreground">Select one tag to see the matching repositories.</div>
+                )}
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {tagSummaries.map((summary) => {
+                  const selected = selectedTag === summary.tag
+                  return (
+                    <button
+                      key={summary.tag}
+                      type="button"
+                      onClick={() => setSelectedTag(selected ? null : summary.tag)}
+                      className={cn(
+                        "inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors",
+                        selected
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+                      )}
+                      aria-pressed={selected}
+                    >
+                      <Tag className="h-4 w-4" />
+                      <span>{summary.tag}</span>
+                      <span className="rounded-full bg-background/80 px-2 py-0.5 text-xs text-muted-foreground">
+                        {summary.repoCount}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="overflow-hidden rounded-md border border-border bg-card">
+              {selectedSummary ? (
+                <>
+                  <div className="border-b border-border px-5 py-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                        <Tag className="h-3.5 w-3.5" />
+                        {selectedSummary.tag}
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {selectedSummary.repoCount.toLocaleString()} {selectedSummary.repoCount === 1 ? "repository" : "repositories"}
+                      </span>
+                    </div>
+                  </div>
+                  {selectedSummary.repos.map((fullName) => {
+                    const { owner, repo } = splitFullName(fullName)
+                    return (
+                      <div
+                        key={fullName}
+                        className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
+                      >
+                        <div className="min-w-0 flex-1 space-y-1">
+                          <Link
+                            href={`/${owner}/${repo}`}
+                            className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                          >
+                            {fullName}
+                          </Link>
+                          <div className="text-xs text-muted-foreground">
+                            Tagged with <span className="font-medium text-foreground">{selectedSummary.tag}</span>
+                          </div>
+                        </div>
+                        <Link
+                          href={`/${owner}/${repo}`}
+                          className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
+                        >
+                          Open
+                          <ArrowRight className="h-3.5 w-3.5" />
+                        </Link>
+                      </div>
+                    )
+                  })}
+                </>
+              ) : (
+                <div className="p-6 text-sm leading-7 text-muted-foreground">
+                  Select a tag above to view the repositories saved under it.
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </section>
+    </RepoShell>
+  )
+}

--- a/web/src/components/repo-shell.tsx
+++ b/web/src/components/repo-shell.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react"
 import type { ReactNode } from "react"
 import Link from "next/link"
-import { ArrowUpRight, Bookmark, Clock, Eye, Shuffle, StickyNote, Menu, X } from "lucide-react"
+import { ArrowUpRight, Bookmark, Clock, Eye, Shuffle, StickyNote, Tag, Menu, X } from "lucide-react"
 
 import { ThemeToggle } from "@/components/theme-toggle"
 import { CommandPalette } from "@/components/command-palette"
@@ -35,6 +35,10 @@ function Navigation({ onNavigate }: { onNavigate?: () => void }) {
       <Link href="/notes" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")} onClick={onNavigate}>
         <StickyNote className="h-4 w-4" />
         Notes
+      </Link>
+      <Link href="/tags" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")} onClick={onNavigate}>
+        <Tag className="h-4 w-4" />
+        Tags
       </Link>
       <Link href="/discover" className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 text-muted-foreground")} onClick={onNavigate}>
         <Shuffle className="h-4 w-4" />

--- a/web/src/lib/tags.ts
+++ b/web/src/lib/tags.ts
@@ -2,9 +2,30 @@ import { createMapStore } from "./local-storage"
 
 export type TagsMap = Record<string, string[]>
 
+export type TagSummary = {
+  tag: string
+  repoCount: number
+  repos: string[]
+}
+
+export const TAGS_STORAGE_KEY = "discofork-tags"
+export const TAGS_CHANGE_EVENT = "discofork:tags-changed"
+
 const store = createMapStore<string[]>({
-  storageKey: "discofork-tags",
+  storageKey: TAGS_STORAGE_KEY,
 })
+
+function emitTagsChange(): void {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent(TAGS_CHANGE_EVENT))
+}
+
+function sameTags(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((tag, index) => tag === right[index])
+}
 
 export const getTags = store.getAll
 
@@ -14,11 +35,18 @@ export function getRepoTags(fullName: string): string[] {
 
 export function setRepoTags(fullName: string, repoTags: string[]): void {
   const cleaned = [...new Set(repoTags.map((t) => t.trim().toLowerCase()).filter(Boolean))].sort()
+  const current = getRepoTags(fullName)
+
+  if (sameTags(current, cleaned)) {
+    return
+  }
+
   if (cleaned.length === 0) {
     store.remove(fullName)
   } else {
     store.set(fullName, cleaned)
   }
+  emitTagsChange()
 }
 
 export function addTag(fullName: string, tag: string): string[] {
@@ -39,20 +67,38 @@ export function removeTag(fullName: string, tag: string): string[] {
   return updated
 }
 
-export function getAllTags(): string[] {
-  const tags = getTags()
+export function getAllTags(tagsMap: TagsMap = getTags()): string[] {
   const allTags = new Set<string>()
-  for (const repoTags of Object.values(tags)) {
+  for (const repoTags of Object.values(tagsMap)) {
     for (const tag of repoTags) {
       allTags.add(tag)
     }
   }
-  return [...allTags].sort()
+  return [...allTags].sort((a, b) => a.localeCompare(b))
 }
 
-export function getReposByTag(tag: string): string[] {
-  const tags = getTags()
-  return Object.entries(tags)
+export function getReposByTag(tag: string, tagsMap: TagsMap = getTags()): string[] {
+  return Object.entries(tagsMap)
     .filter(([, repoTags]) => repoTags.includes(tag))
     .map(([fullName]) => fullName)
+    .sort((a, b) => a.localeCompare(b))
+}
+
+export function getTagSummaries(tagsMap: TagsMap = getTags()): TagSummary[] {
+  return getAllTags(tagsMap).map((tag) => {
+    const repos = getReposByTag(tag, tagsMap)
+    return {
+      tag,
+      repoCount: repos.length,
+      repos,
+    }
+  })
+}
+
+export function getTagSummary(tag: string | null, tagsMap: TagsMap = getTags()): TagSummary | null {
+  if (!tag) {
+    return null
+  }
+
+  return getTagSummaries(tagsMap).find((summary) => summary.tag === tag) ?? null
 }


### PR DESCRIPTION
Closes #114

## Summary
- add a dedicated client-side `/tags` page for browsing saved local repository tags
- show tag counts, one-at-a-time selection, and linked repositories for the selected tag
- wire the new page into the shared desktop/mobile navigation and add focused Bun coverage for tag summaries and refresh behavior

## Why this improves Discofork
Tags were already storable on repository pages, but they were difficult to revisit later. This turns tags into a usable local organization surface without adding any backend complexity.

## Validation
- `npx bun test test/tags-page.test.ts`
- `cd web && npx bun run typecheck`
- `cd web && npx bun run build`
- `git diff --check`

## Review gate
- Used reviewer-only fallback because full `review-changes` orchestration was unavailable in this environment.
- The first review pass flagged redundant no-op tag change events; this PR adds a `sameTags(...)` guard in `web/src/lib/tags.ts` and the follow-up reviewer-only pass approved the diff.

## Risks / follow-ups
- Tags remain browser-local only, so the page reflects each browser's saved data rather than a shared backend collection.
- A future follow-up could add a render-level interaction test for storage/custom-event sync on the `/tags` page.

## Exec plan
- `.hermes/plans/2026-04-16-tags-page.md`
