### PR TITLE
feat: add local workspace repo launcher

### DIFF
--- a/test/local-client-repo-actions.test.ts
+++ b/test/local-client-repo-actions.test.ts
@@ -7,6 +7,13 @@ import {
   toggleBookmark,
 } from "../web/src/lib/bookmarks"
 import {
+  addHistory,
+  clearHistory,
+  getHistory,
+  HISTORY_CHANGE_EVENT,
+  removeHistory,
+} from "../web/src/lib/history"
+import {
   WATCHES_CHANGE_EVENT,
   getWatches,
   isWatched,
@@ -101,5 +108,26 @@ describe("local client repo action stores", () => {
       new Date(watchedBeforeTouch.lastVisitedAt).getTime(),
     )
     expect(watchEventCounts).toEqual([1, 1])
+  })
+
+  test("history mutations emit same-page change events", async () => {
+    const historySnapshots: string[][] = []
+
+    window.addEventListener(HISTORY_CHANGE_EVENT, () => {
+      historySnapshots.push(getHistory().map((entry) => entry.fullName))
+    })
+
+    addHistory("openai", "codex")
+    await Bun.sleep(5)
+    addHistory("vercel", "next.js")
+    removeHistory("openai/codex")
+    clearHistory()
+
+    expect(historySnapshots).toEqual([
+      ["openai/codex"],
+      ["vercel/next.js", "openai/codex"],
+      ["vercel/next.js"],
+      [],
+    ])
   })
 })

--- a/test/repo-launcher.test.ts
+++ b/test/repo-launcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  buildRepoLauncherSearchResults,
   filterRepoLauncherSuggestions,
   mergeRepoLauncherSuggestions,
   parseRepoLauncherInput,
@@ -99,6 +100,50 @@ describe("repo launcher suggestions", () => {
     expect(filterRepoLauncherSuggestions(suggestions, "").map((entry) => entry.fullName)).toEqual([
       "vercel/next.js",
       "openai/codex",
+    ])
+  })
+
+  test("builds merged search results from typed repos, cached API hits, and local suggestions", () => {
+    const suggestions = mergeRepoLauncherSuggestions({
+      history: [{ owner: "openai", repo: "codex", visitedAt: "2026-04-14T20:00:00Z" }],
+      bookmarks: [{ owner: "vercel", repo: "next.js", bookmarkedAt: "2026-04-14T21:00:00Z" }],
+      limit: 5,
+    })
+
+    const results = buildRepoLauncherSearchResults({
+      query: "https://github.com/openai/codex",
+      apiResults: [
+        {
+          owner: "vercel",
+          repo: "next.js",
+          fullName: "vercel/next.js",
+          canonicalPath: "/vercel/next.js",
+          stars: 130000,
+          upstreamSummary: "The React framework for the web.",
+        },
+      ],
+      suggestions,
+      limit: 5,
+    })
+
+    expect(results.map((result) => ({ fullName: result.fullName, kind: result.kind, sources: result.sources }))).toEqual([
+      { fullName: "openai/codex", kind: "direct", sources: ["recent"] },
+      { fullName: "vercel/next.js", kind: "cached", sources: ["bookmarked"] },
+    ])
+  })
+
+  test("returns top local suggestions when the search query is empty", () => {
+    const suggestions = mergeRepoLauncherSuggestions({
+      history: [{ owner: "openai", repo: "codex", visitedAt: "2026-04-14T20:00:00Z" }],
+      watches: [{ owner: "schema-labs-ltd", repo: "discofork", watchedAt: "2026-04-14T21:00:00Z", lastVisitedAt: "2026-04-14T21:30:00Z" }],
+      limit: 5,
+    })
+
+    const results = buildRepoLauncherSearchResults({ query: "", suggestions, limit: 5 })
+
+    expect(results.map((result) => ({ fullName: result.fullName, kind: result.kind }))).toEqual([
+      { fullName: "schema-labs-ltd/discofork", kind: "local" },
+      { fullName: "openai/codex", kind: "local" },
     ])
   })
 })

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { ArrowRight, Terminal } from "lucide-react"
 
 import { CopyInstallButton } from "@/components/copy-install-button"
+import { LocalWorkspacePanel } from "@/components/local-workspace-panel"
 import { QueueInput } from "@/components/queue-input"
 import { RandomDiscoveryButton } from "@/components/random-discovery-button"
 import { RecentlyViewedWidget } from "@/components/recently-viewed-widget"
@@ -133,6 +134,10 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+
+      <div className="mt-10 sm:mt-14">
+        <LocalWorkspacePanel />
+      </div>
 
       <div className="mt-10 sm:mt-14">
         <TrendingRepos />

--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { Database, Search } from "lucide-react"
 
 import { CompareBar } from "@/components/compare-toggle"
+import { LocalWorkspacePanel } from "@/components/local-workspace-panel"
 import { QueueInput } from "@/components/queue-input"
 import { RepoOrderSelect } from "@/components/repo-order-select"
 import { RepoLanguageFilter } from "@/components/repo-language-filter"
@@ -234,8 +235,14 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
         </div>
 
         {!view.databaseEnabled ? (
-          <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
-            `DATABASE_URL` is not configured for the web backend yet, so the repository index is unavailable.
+          <div className="space-y-4">
+            <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+              `DATABASE_URL` is not configured for the web backend yet, so the repository index is unavailable.
+            </div>
+            <LocalWorkspacePanel
+              title="Keep exploring from local context"
+              description="Discofork can still help you bounce between repositories you already viewed, bookmarked, or watched in this browser while the shared backend cache is unavailable."
+            />
           </div>
         ) : displayView.items.length === 0 ? (
           <div className="rounded-md border border-border bg-card p-6 space-y-4">

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -1,18 +1,19 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Loader2, Search, Star, X } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
+import { useRepoLauncherWorkspace } from "@/hooks/use-repo-launcher-workspace"
 import { createLatestRequestGuard } from "@/lib/latest-request-guard"
+import {
+  buildRepoLauncherSearchResults,
+  REPO_LAUNCHER_SUGGESTION_LABELS,
+  type RepoLauncherCachedResult,
+} from "@/lib/repo-launcher"
 
-type PaletteResult = {
-  fullName: string
-  owner: string
-  repo: string
-  stars: number | null
-  upstreamSummary: string | null
-}
+type PaletteApiResult = RepoLauncherCachedResult
 
 const MAX_RESULTS = 8
 const DEBOUNCE_MS = 300
@@ -27,17 +28,25 @@ function truncate(text: string | null, max: number): string {
 export function CommandPalette() {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
-  const [results, setResults] = useState<PaletteResult[]>([])
+  const [apiResults, setApiResults] = useState<PaletteApiResult[]>([])
   const [loading, setLoading] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const [apiStatus, setApiStatus] = useState<"idle" | "ready" | "unavailable">("idle")
   const inputRef = useRef<HTMLInputElement>(null)
   const latestSearchRef = useRef<ReturnType<typeof createLatestRequestGuard> | null>(null)
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { suggestions } = useRepoLauncherWorkspace(MAX_RESULTS)
+
   if (latestSearchRef.current === null) {
     latestSearchRef.current = createLatestRequestGuard()
   }
   const latestSearch = latestSearchRef.current
   const router = useRouter()
+
+  const results = useMemo(
+    () => buildRepoLauncherSearchResults({ query, apiResults, suggestions, limit: MAX_RESULTS }),
+    [apiResults, query, suggestions],
+  )
 
   const clearPendingSearchTimer = useCallback(() => {
     if (searchTimerRef.current !== null) {
@@ -46,36 +55,35 @@ export function CommandPalette() {
     }
   }, [])
 
-  const updateQuery = useCallback((nextQuery: string) => {
-    clearPendingSearchTimer()
-    latestSearch.invalidate()
-    setQuery(nextQuery)
-    setResults([])
-    setHighlightedIndex(-1)
-    setLoading(nextQuery.trim().length > 0)
-  }, [clearPendingSearchTimer, latestSearch])
+  const updateQuery = useCallback(
+    (nextQuery: string) => {
+      clearPendingSearchTimer()
+      latestSearch.invalidate()
+      setQuery(nextQuery)
+      setApiResults([])
+      setHighlightedIndex(-1)
+      setApiStatus("idle")
+      setLoading(nextQuery.trim().length > 0)
+    },
+    [clearPendingSearchTimer, latestSearch],
+  )
 
   const closePalette = useCallback(() => {
     clearPendingSearchTimer()
     latestSearch.invalidate()
     setOpen(false)
     setQuery("")
-    setResults([])
+    setApiResults([])
     setHighlightedIndex(-1)
     setLoading(false)
+    setApiStatus("idle")
   }, [clearPendingSearchTimer, latestSearch])
 
-  // Global shortcut: Cmd+K / Ctrl+K (skip when focus is in an input-like element)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         const target = e.target as HTMLElement | null
-        if (
-          target &&
-          (target.tagName === "INPUT" ||
-            target.tagName === "TEXTAREA" ||
-            target.isContentEditable)
-        ) {
+        if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
           return
         }
         e.preventDefault()
@@ -91,7 +99,6 @@ export function CommandPalette() {
     return () => document.removeEventListener("keydown", handleKeyDown)
   }, [closePalette, open])
 
-  // Focus input when opening
   useEffect(() => {
     if (open) {
       const frame = requestAnimationFrame(() => inputRef.current?.focus())
@@ -106,7 +113,6 @@ export function CommandPalette() {
     }
   }, [clearPendingSearchTimer, latestSearch])
 
-  // Escape closes the palette
   useEffect(() => {
     if (!open) return
 
@@ -121,7 +127,6 @@ export function CommandPalette() {
     return () => document.removeEventListener("keydown", handleEscape)
   }, [closePalette, open])
 
-  // Prevent body scroll when open
   useEffect(() => {
     if (open) {
       document.body.style.overflow = "hidden"
@@ -131,7 +136,10 @@ export function CommandPalette() {
     }
   }, [open])
 
-  // Debounced search
+  useEffect(() => {
+    setHighlightedIndex(results.length > 0 ? 0 : -1)
+  }, [results])
+
   useEffect(() => {
     clearPendingSearchTimer()
 
@@ -140,9 +148,9 @@ export function CommandPalette() {
     }
 
     const trimmedQuery = query.trim()
-
     if (!trimmedQuery) {
-      setResults([])
+      setApiResults([])
+      setApiStatus("idle")
       setLoading(false)
       return
     }
@@ -153,33 +161,36 @@ export function CommandPalette() {
       const request = latestSearch.begin()
 
       try {
-        const params = new URLSearchParams({
-          query: trimmedQuery,
-          status: "ready",
-          page: "1",
-        })
+        const params = new URLSearchParams({ query: trimmedQuery, status: "ready", page: "1" })
         const res = await fetch(`/api/repos?${params}`, { signal: request.signal })
-        if (!res.ok || !request.isCurrent()) return
+        if (!res.ok || !request.isCurrent()) {
+          if (request.isCurrent()) {
+            setApiStatus("unavailable")
+          }
+          return
+        }
 
         const data = await res.json()
         if (!request.isCurrent()) return
 
-        const items: PaletteResult[] = (data.items ?? []).slice(0, MAX_RESULTS).map(
-          (item: Record<string, unknown>) => ({
-            fullName: item.fullName,
-            owner: item.owner,
-            repo: item.repo,
-            stars: item.stars,
-            upstreamSummary: item.upstreamSummary,
-          }),
-        )
-        setResults(items)
-        setHighlightedIndex(items.length > 0 ? 0 : -1)
+        const items: PaletteApiResult[] = (data.items ?? []).slice(0, MAX_RESULTS).map((item: Record<string, unknown>) => ({
+          fullName: item.fullName as string,
+          owner: item.owner as string,
+          repo: item.repo as string,
+          stars: (item.stars as number | null | undefined) ?? null,
+          upstreamSummary: (item.upstreamSummary as string | null | undefined) ?? null,
+          canonicalPath: `/${item.owner as string}/${item.repo as string}`,
+        }))
+        setApiResults(items)
+        setApiStatus("ready")
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
           return
         }
-        // Silent fail — palette just stays empty
+        if (request.isCurrent()) {
+          setApiStatus("unavailable")
+          setApiResults([])
+        }
       } finally {
         if (request.isCurrent()) {
           setLoading(false)
@@ -190,9 +201,8 @@ export function CommandPalette() {
     return () => {
       clearPendingSearchTimer()
     }
-  }, [clearPendingSearchTimer, open, query])
+  }, [clearPendingSearchTimer, latestSearch, open, query])
 
-  // Keyboard navigation within results
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "ArrowDown") {
@@ -208,7 +218,7 @@ export function CommandPalette() {
         router.push(`/${item.owner}/${item.repo}`)
       }
     },
-    [closePalette, results, highlightedIndex, router],
+    [closePalette, highlightedIndex, results, router],
   )
 
   const navigateTo = useCallback(
@@ -222,15 +232,8 @@ export function CommandPalette() {
   if (!open) return null
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] bg-background/80 backdrop-blur-sm"
-      onClick={closePalette}
-    >
-      <div
-        className="relative w-full max-w-lg rounded-lg border border-border bg-card shadow-lg"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Search input */}
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-background/80 pt-[15vh] backdrop-blur-sm" onClick={closePalette}>
+      <div className="relative w-full max-w-lg rounded-lg border border-border bg-card shadow-lg" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center gap-3 border-b border-border px-4 py-3">
           <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
           <input
@@ -239,7 +242,7 @@ export function CommandPalette() {
             value={query}
             onChange={(e) => updateQuery(e.target.value)}
             onKeyDown={handleInputKeyDown}
-            placeholder="Search repositories…"
+            placeholder="Search cached repos, paste owner/repo, or jump from local context…"
             className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
             aria-label="Search repositories"
           />
@@ -254,12 +257,11 @@ export function CommandPalette() {
           </button>
         </div>
 
-        {/* Results */}
         {results.length > 0 && (
-          <div className="max-h-[300px] overflow-y-auto py-1">
+          <div className="max-h-[320px] overflow-y-auto py-1">
             {results.map((item, index) => (
               <button
-                key={item.fullName}
+                key={`${item.kind}-${item.fullName}`}
                 type="button"
                 onClick={() => navigateTo(item.owner, item.repo)}
                 onMouseEnter={() => setHighlightedIndex(index)}
@@ -268,61 +270,67 @@ export function CommandPalette() {
                 }`}
               >
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <span className="text-sm font-medium text-foreground">{item.fullName}</span>
-                    {item.stars != null && item.stars > 0 && (
+                    <Badge variant={item.kind === "direct" ? "success" : "muted"}>
+                      {item.kind === "direct" ? "Typed repo" : item.kind === "cached" ? "Cached repo" : "Local context"}
+                    </Badge>
+                    {item.stars != null && item.stars > 0 ? (
                       <span className="flex items-center gap-1 text-xs text-muted-foreground">
                         <Star className="h-3 w-3" />
                         {item.stars.toLocaleString()}
                       </span>
-                    )}
+                    ) : null}
                   </div>
-                  {item.upstreamSummary && (
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {truncate(item.upstreamSummary, MAX_SUMMARY_LENGTH)}
-                    </p>
-                  )}
+                  {item.upstreamSummary ? (
+                    <p className="mt-0.5 text-xs text-muted-foreground">{truncate(item.upstreamSummary, MAX_SUMMARY_LENGTH)}</p>
+                  ) : null}
+                  {item.sources.length > 0 ? (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {item.sources.map((source) => (
+                        <Badge key={`${item.fullName}-${source}`} variant="muted">
+                          {REPO_LAUNCHER_SUGGESTION_LABELS[source]}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
               </button>
             ))}
           </div>
         )}
 
-        {/* Empty state */}
         {query.trim() && !loading && results.length === 0 && (
-          <div className="px-4 py-6 text-center text-sm text-muted-foreground">
-            No repositories found.
+          <div className="space-y-2 px-4 py-6 text-center text-sm text-muted-foreground">
+            <p>No repositories matched.</p>
+            <p className="text-xs">
+              Try an owner/repo, GitHub URL, or one of the repositories you already viewed in this browser.
+            </p>
           </div>
         )}
 
-        {/* Hint when query is empty */}
         {!query.trim() && !loading && (
-          <div className="px-4 py-6 text-center text-xs text-muted-foreground">
-            Type to search across cached repositories…
+          <div className="space-y-2 px-4 py-6 text-center text-xs text-muted-foreground">
+            <p>Start typing to search cached repositories.</p>
+            <p>Recent, bookmarked, and watched repositories appear here automatically.</p>
           </div>
         )}
 
-        {/* Footer hint */}
         <div className="border-t border-border px-4 py-2">
-          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
             <span>
-              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
-                ↑↓
-              </kbd>{" "}
+              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">↑↓</kbd>{" "}
               navigate
             </span>
             <span>
-              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
-                ↵
-              </kbd>{" "}
+              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">↵</kbd>{" "}
               select
             </span>
             <span>
-              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
-                esc
-              </kbd>{" "}
+              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">esc</kbd>{" "}
               close
             </span>
+            {apiStatus === "unavailable" ? <span>API unavailable — showing local results</span> : null}
           </div>
         </div>
       </div>

--- a/web/src/components/local-workspace-panel.tsx
+++ b/web/src/components/local-workspace-panel.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowRight, Bookmark, Clock3, Eye } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { buttonVariants } from "@/components/ui/button"
+import { useRepoLauncherWorkspace } from "@/hooks/use-repo-launcher-workspace"
+import { REPO_LAUNCHER_SUGGESTION_LABELS } from "@/lib/repo-launcher"
+import { cn } from "@/lib/utils"
+
+export function LocalWorkspacePanel({
+  title = "Continue from your browser workspace",
+  description = "Recent, bookmarked, and watched repositories stay in this browser so you can get back to work quickly even before the backend cache is populated.",
+  limit = 6,
+}: {
+  title?: string
+  description?: string
+  limit?: number
+}) {
+  const { bookmarks, history, mounted, suggestions, watches } = useRepoLauncherWorkspace(limit)
+
+  if (!mounted) {
+    return null
+  }
+
+  const hasWorkspace = suggestions.length > 0 || bookmarks.length > 0 || watches.length > 0 || history.length > 0
+  if (!hasWorkspace) {
+    return null
+  }
+
+  return (
+    <section className="space-y-5 rounded-[1.25rem] border border-border bg-card/70 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.28)] sm:p-6">
+      <div className="space-y-2">
+        <div className="font-mono text-xs uppercase tracking-[0.24em] text-muted-foreground">Local workspace</div>
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        <p className="text-sm leading-7 text-muted-foreground">{description}</p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-xl border border-border bg-background/60 p-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <Clock3 className="h-4 w-4 text-primary" />
+            Recent
+          </div>
+          <div className="mt-2 text-2xl font-semibold text-foreground">{history.length}</div>
+        </div>
+        <div className="rounded-xl border border-border bg-background/60 p-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <Bookmark className="h-4 w-4 text-primary" />
+            Bookmarked
+          </div>
+          <div className="mt-2 text-2xl font-semibold text-foreground">{bookmarks.length}</div>
+        </div>
+        <div className="rounded-xl border border-border bg-background/60 p-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <Eye className="h-4 w-4 text-primary" />
+            Watching
+          </div>
+          <div className="mt-2 text-2xl font-semibold text-foreground">{watches.length}</div>
+        </div>
+      </div>
+
+      {suggestions.length > 0 ? (
+        <div className="space-y-3">
+          <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Quick picks</div>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {suggestions.map((suggestion) => (
+              <Link
+                key={suggestion.fullName}
+                href={suggestion.canonicalPath}
+                className="rounded-xl border border-border bg-background/60 p-4 transition-colors hover:border-primary/40 hover:bg-background"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-semibold text-foreground">{suggestion.fullName}</div>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {suggestion.sources.map((source) => (
+                        <Badge key={`${suggestion.fullName}-${source}`} variant="muted">
+                          {REPO_LAUNCHER_SUGGESTION_LABELS[source]}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                  <ArrowRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-3">
+        <Link href="/recent" className={cn(buttonVariants({ variant: "outline" }), "rounded-full px-4")}>
+          Open recent
+        </Link>
+        <Link href="/bookmarks" className={cn(buttonVariants({ variant: "outline" }), "rounded-full px-4")}>
+          Open bookmarks
+        </Link>
+        <Link href="/watched" className={cn(buttonVariants({ variant: "outline" }), "rounded-full px-4")}>
+          Open watched
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/quick-jump-dialog.tsx
+++ b/web/src/components/quick-jump-dialog.tsx
@@ -1,26 +1,50 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { ArrowRight, Slash } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { useRepoLauncherWorkspace } from "@/hooks/use-repo-launcher-workspace"
+import {
+  buildRepoLauncherSearchResults,
+  parseRepoLauncherInput,
+  REPO_LAUNCHER_SUGGESTION_LABELS,
+} from "@/lib/repo-launcher"
 
 export function QuickJumpDialog() {
   const [open, setOpen] = useState(false)
   const [value, setValue] = useState("")
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const inputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
+  const { suggestions } = useRepoLauncherWorkspace(8)
+
+  const results = useMemo(
+    () => buildRepoLauncherSearchResults({ query: value, suggestions, limit: 8 }),
+    [suggestions, value],
+  )
+
+  const closeDialog = useCallback(() => {
+    setOpen(false)
+    setValue("")
+    setHighlightedIndex(-1)
+  }, [])
+
+  const navigateTo = useCallback(
+    (owner: string, repo: string) => {
+      closeDialog()
+      router.push(`/${owner}/${repo}`)
+    },
+    [closeDialog, router],
+  )
 
   // Open with "/" when not focused on an input
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         const target = e.target as HTMLElement | null
-        if (
-          target &&
-          (target.tagName === "INPUT" ||
-            target.tagName === "TEXTAREA" ||
-            target.isContentEditable)
-        ) {
+        if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
           return
         }
         e.preventDefault()
@@ -36,72 +60,85 @@ export function QuickJumpDialog() {
   useEffect(() => {
     if (open) {
       setValue("")
+      setHighlightedIndex(-1)
       const frame = requestAnimationFrame(() => inputRef.current?.focus())
       return () => cancelAnimationFrame(frame)
     }
   }, [open])
 
-  // Escape closes
   useEffect(() => {
     if (!open) return
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault()
-        setOpen(false)
+        closeDialog()
       }
     }
 
     document.addEventListener("keydown", handleEscape)
     return () => document.removeEventListener("keydown", handleEscape)
-  }, [open])
+  }, [closeDialog, open])
 
-  // Prevent body scroll when open
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = "hidden"
-      return () => {
-        document.body.style.overflow = ""
-      }
+    if (!open) return
+
+    document.body.style.overflow = "hidden"
+    return () => {
+      document.body.style.overflow = ""
     }
   }, [open])
+
+  useEffect(() => {
+    setHighlightedIndex(results.length > 0 ? 0 : -1)
+  }, [results])
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault()
-      const trimmed = value.trim()
-      if (!trimmed) return
+      const highlighted = highlightedIndex >= 0 ? results[highlightedIndex] : null
+      if (highlighted) {
+        navigateTo(highlighted.owner, highlighted.repo)
+        return
+      }
 
-      // Basic owner/repo validation
-      const parts = trimmed.split("/")
-      if (parts.length === 2 && parts[0] && parts[1]) {
-        setOpen(false)
-        router.push(`/${parts[0]}/${parts[1]}`)
+      const target = parseRepoLauncherInput(value)
+      if (target) {
+        navigateTo(target.owner, target.repo)
       }
     },
-    [value, router],
+    [highlightedIndex, navigateTo, results, value],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (results.length === 0) {
+        return
+      }
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        setHighlightedIndex((prev) => (prev < results.length - 1 ? prev + 1 : 0))
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : results.length - 1))
+      }
+    },
+    [results.length],
   )
 
   if (!open) {
     return (
       <div className="hidden items-center gap-1.5 text-[11px] text-muted-foreground sm:flex">
-        <kbd className="rounded border border-border bg-muted/70 px-1.5 py-0.5 font-mono text-[10px]">
-          /
-        </kbd>
+        <kbd className="rounded border border-border bg-muted/70 px-1.5 py-0.5 font-mono text-[10px]">/</kbd>
         <span>jump to repo</span>
       </div>
     )
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] bg-background/80 backdrop-blur-sm"
-      onClick={() => setOpen(false)}
-    >
-      <div
-        className="relative w-full max-w-md rounded-lg border border-border bg-card shadow-lg"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-background/80 pt-[15vh] backdrop-blur-sm" onClick={closeDialog}>
+      <div className="relative w-full max-w-xl rounded-lg border border-border bg-card shadow-lg" onClick={(e) => e.stopPropagation()}>
         <form onSubmit={handleSubmit} className="flex items-center gap-3 border-b border-border px-4 py-3">
           <Slash className="h-4 w-4 shrink-0 text-muted-foreground" />
           <input
@@ -109,36 +146,71 @@ export function QuickJumpDialog() {
             type="text"
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            placeholder="owner/repo"
+            onKeyDown={handleKeyDown}
+            placeholder="owner/repo or https://github.com/owner/repo"
             className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
             aria-label="Navigate to repository"
           />
           <button
             type="submit"
-            disabled={!value.trim().includes("/")}
+            disabled={results.length === 0 && !parseRepoLauncherInput(value)}
             className="rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-30"
             aria-label="Go"
           >
             <ArrowRight className="h-4 w-4" />
           </button>
         </form>
-        <div className="px-4 py-3">
-          <p className="text-xs text-muted-foreground">
-            Type <span className="font-mono font-medium text-foreground">owner/repo</span> and press Enter to navigate directly to the repository brief.
-          </p>
-        </div>
+
+        {results.length > 0 ? (
+          <div className="max-h-[320px] overflow-y-auto py-2">
+            {results.map((result, index) => (
+              <button
+                key={`${result.kind}-${result.fullName}`}
+                type="button"
+                onClick={() => navigateTo(result.owner, result.repo)}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors ${
+                  index === highlightedIndex ? "bg-muted/50" : "hover:bg-muted/30"
+                }`}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">{result.fullName}</span>
+                    <Badge variant={result.kind === "direct" ? "success" : "muted"}>
+                      {result.kind === "direct" ? "Typed repo" : result.kind === "cached" ? "Cached repo" : "Local context"}
+                    </Badge>
+                  </div>
+                  {result.sources.length > 0 ? (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {result.sources.map((source) => (
+                        <Badge key={`${result.fullName}-${source}`} variant="muted">
+                          {REPO_LAUNCHER_SUGGESTION_LABELS[source]}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="px-4 py-4 text-xs text-muted-foreground">
+            Type an owner/repo, GitHub URL, or Discofork URL. Recent, bookmarked, and watched repositories appear here automatically.
+          </div>
+        )}
+
         <div className="border-t border-border px-4 py-2">
-          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
             <span>
-              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
-                ↵
-              </kbd>{" "}
+              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">↑↓</kbd>{" "}
               navigate
             </span>
             <span>
-              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">
-                esc
-              </kbd>{" "}
+              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">↵</kbd>{" "}
+              open repo
+            </span>
+            <span>
+              <kbd className="rounded border border-border bg-muted/70 px-1 py-0.5 font-mono text-[10px]">esc</kbd>{" "}
               close
             </span>
           </div>

--- a/web/src/hooks/use-repo-launcher-workspace.ts
+++ b/web/src/hooks/use-repo-launcher-workspace.ts
@@ -1,0 +1,59 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { BOOKMARKS_CHANGE_EVENT, getBookmarks, type BookmarkEntry } from "@/lib/bookmarks"
+import { getHistory, HISTORY_CHANGE_EVENT, type HistoryEntry } from "@/lib/history"
+import { getRepoLauncherSuggestions, type RepoLauncherSuggestion } from "@/lib/repo-launcher"
+import { getWatches, WATCHES_CHANGE_EVENT, type WatchEntry } from "@/lib/watches"
+
+type RepoLauncherWorkspace = {
+  bookmarks: BookmarkEntry[]
+  history: HistoryEntry[]
+  mounted: boolean
+  suggestions: RepoLauncherSuggestion[]
+  watches: WatchEntry[]
+}
+
+function readWorkspace(limit: number): Omit<RepoLauncherWorkspace, "mounted"> {
+  return {
+    bookmarks: getBookmarks(),
+    history: getHistory(),
+    suggestions: getRepoLauncherSuggestions(limit),
+    watches: getWatches(),
+  }
+}
+
+export function useRepoLauncherWorkspace(limit = 8): RepoLauncherWorkspace {
+  const [workspace, setWorkspace] = useState<RepoLauncherWorkspace>({
+    bookmarks: [],
+    history: [],
+    mounted: false,
+    suggestions: [],
+    watches: [],
+  })
+
+  const refresh = useCallback(() => {
+    setWorkspace({
+      ...readWorkspace(limit),
+      mounted: true,
+    })
+  }, [limit])
+
+  useEffect(() => {
+    refresh()
+
+    const handleChange = () => refresh()
+    window.addEventListener(BOOKMARKS_CHANGE_EVENT, handleChange)
+    window.addEventListener(HISTORY_CHANGE_EVENT, handleChange)
+    window.addEventListener(WATCHES_CHANGE_EVENT, handleChange)
+
+    return () => {
+      window.removeEventListener(BOOKMARKS_CHANGE_EVENT, handleChange)
+      window.removeEventListener(HISTORY_CHANGE_EVENT, handleChange)
+      window.removeEventListener(WATCHES_CHANGE_EVENT, handleChange)
+    }
+  }, [refresh])
+
+  return workspace
+}

--- a/web/src/lib/history.ts
+++ b/web/src/lib/history.ts
@@ -21,8 +21,26 @@ const store = createArrayStore<HistoryEntry>({
   }),
 })
 
+export const HISTORY_CHANGE_EVENT = "discofork:history-change"
+
+function emitHistoryChange(history: HistoryEntry[] = getHistory()): void {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<{ history: HistoryEntry[] }>(HISTORY_CHANGE_EVENT, {
+      detail: { history },
+    }),
+  )
+}
+
 export const getHistory = store.getAll
-export const removeHistory = store.remove
+
+export function removeHistory(fullName: string): void {
+  store.remove(fullName)
+  emitHistoryChange(getHistory())
+}
 
 /**
  * Add or update a history entry with max-entries cap and recency sorting.
@@ -38,6 +56,7 @@ export function addHistory(owner: string, repo: string): void {
     history.sort((a, b) => new Date(b.visitedAt).getTime() - new Date(a.visitedAt).getTime())
     if (typeof window !== "undefined") {
       localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history))
+      emitHistoryChange(history)
     }
     return
   }
@@ -52,11 +71,13 @@ export function addHistory(owner: string, repo: string): void {
   const updated = [entry, ...history].slice(0, MAX_HISTORY_ENTRIES)
   if (typeof window !== "undefined") {
     localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(updated))
+    emitHistoryChange(updated)
   }
 }
 
 export function clearHistory(): void {
   if (typeof window !== "undefined") {
     localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify([]))
+    emitHistoryChange([])
   }
 }

--- a/web/src/lib/repo-launcher.ts
+++ b/web/src/lib/repo-launcher.ts
@@ -31,6 +31,18 @@ export type RepoLauncherSuggestion = RepoLauncherTarget & {
   lastTouchedAt: string | null
 }
 
+export type RepoLauncherCachedResult = RepoLauncherTarget & {
+  stars: number | null
+  upstreamSummary: string | null
+}
+
+export type RepoLauncherSearchResult = RepoLauncherTarget & {
+  kind: "direct" | "cached" | "local"
+  stars: number | null
+  upstreamSummary: string | null
+  sources: RepoLauncherSuggestionSource[]
+}
+
 export const REPO_LAUNCHER_SUGGESTION_LABELS: Record<RepoLauncherSuggestionSource, string> = {
   recent: "Recent",
   bookmarked: "Bookmarked",
@@ -125,6 +137,19 @@ function addSuggestion(
   }
 }
 
+function addSearchResult(
+  results: RepoLauncherSearchResult[],
+  seen: Set<string>,
+  result: RepoLauncherSearchResult | null,
+): void {
+  if (!result || seen.has(result.fullName)) {
+    return
+  }
+
+  seen.add(result.fullName)
+  results.push(result)
+}
+
 export function parseRepoLauncherInput(raw: string): RepoLauncherTarget | null {
   const candidatePath = normalizeRepoPathCandidate(raw)
   if (!candidatePath) {
@@ -163,6 +188,68 @@ export function filterRepoLauncherSuggestions(
   }
 
   return suggestions.filter((suggestion) => suggestion.fullName.toLowerCase().includes(normalizedQuery))
+}
+
+export function buildRepoLauncherSearchResults({
+  query,
+  apiResults = [],
+  suggestions = [],
+  limit = 8,
+}: {
+  query: string
+  apiResults?: RepoLauncherCachedResult[]
+  suggestions?: RepoLauncherSuggestion[]
+  limit?: number
+}): RepoLauncherSearchResult[] {
+  const trimmedQuery = query.trim()
+  const results: RepoLauncherSearchResult[] = []
+  const seen = new Set<string>()
+  const suggestionByFullName = new Map(suggestions.map((suggestion) => [suggestion.fullName, suggestion]))
+
+  if (!trimmedQuery) {
+    return suggestions.slice(0, limit).map((suggestion) => ({
+      ...suggestion,
+      kind: "local",
+      stars: null,
+      upstreamSummary: null,
+    }))
+  }
+
+  const directMatch = parseRepoLauncherInput(trimmedQuery)
+  addSearchResult(
+    results,
+    seen,
+    directMatch
+      ? {
+          ...directMatch,
+          kind: "direct",
+          stars: null,
+          upstreamSummary: null,
+          sources: suggestionByFullName.get(directMatch.fullName)?.sources ?? [],
+        }
+      : null,
+  )
+
+  for (const apiResult of apiResults) {
+    const suggestion = suggestionByFullName.get(apiResult.fullName)
+    addSearchResult(results, seen, {
+      ...apiResult,
+      kind: "cached",
+      sources: suggestion?.sources ?? [],
+    })
+  }
+
+  for (const suggestion of filterRepoLauncherSuggestions(suggestions, trimmedQuery)) {
+    addSearchResult(results, seen, {
+      ...suggestion,
+      kind: "local",
+      stars: null,
+      upstreamSummary: null,
+      sources: suggestion.sources,
+    })
+  }
+
+  return results.slice(0, limit)
 }
 
 export function mergeRepoLauncherSuggestions({


### PR DESCRIPTION
## Summary
- add a reusable local workspace panel on the home page and repository index fallback state
- upgrade slash quick-jump to parse repo URLs and surface recent, bookmarked, and watched repositories
- make the command palette resilient with direct repo launching plus local-context fallback when API search is unavailable

## Test Plan
- bun test test/repo-launcher.test.ts test/local-client-repo-actions.test.ts
- npm run typecheck
- npm run build
