### PR TITLE
feat: add visitor launchpad and local collection triage

### DIFF
--- a/test/local-repo-collection.test.ts
+++ b/test/local-repo-collection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  filterLocalRepoCollection,
+  summarizeLocalRepoCollection,
+  type LocalRepoCollectionEntry,
+} from "../web/src/lib/local-repo-collection"
+
+const entries: LocalRepoCollectionEntry[] = [
+  {
+    fullName: "openai/codex",
+    owner: "openai",
+    repo: "codex",
+    savedAt: "2026-04-16T20:00:00Z",
+    secondaryLabel: "Viewed 5m ago",
+  },
+  {
+    fullName: "vercel/next.js",
+    owner: "vercel",
+    repo: "next.js",
+    savedAt: "2026-04-16T19:00:00Z",
+    secondaryLabel: "Bookmarked Apr 16",
+  },
+  {
+    fullName: "grafana/grafana",
+    owner: "grafana",
+    repo: "grafana",
+    savedAt: "2026-04-15T12:00:00Z",
+    secondaryLabel: "Watching for updates",
+  },
+]
+
+describe("local repo collection helpers", () => {
+  test("filters by owner, repo, or full name case-insensitively", () => {
+    expect(filterLocalRepoCollection(entries, "NEXT").map((entry) => entry.fullName)).toEqual(["vercel/next.js"])
+    expect(filterLocalRepoCollection(entries, "grafana/grafana").map((entry) => entry.fullName)).toEqual(["grafana/grafana"])
+    expect(filterLocalRepoCollection(entries, "")).toEqual(entries)
+  })
+
+  test("summarizes filtered results for the page header copy", () => {
+    expect(summarizeLocalRepoCollection(3, 3, "")).toBe("3 repositories")
+    expect(summarizeLocalRepoCollection(1, 3, "next")).toBe('1 match for “next”')
+    expect(summarizeLocalRepoCollection(0, 3, "missing")).toBe('0 matches for “missing”')
+  })
+})

--- a/test/starter-repos.test.ts
+++ b/test/starter-repos.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildStarterRepoLookup,
+  getStarterRepoCards,
+  getStarterRepoCollections,
+} from "../web/src/lib/starter-repos"
+
+describe("starter repo launchpad", () => {
+  test("returns curated collections with stable labels and starter cards", () => {
+    const collections = getStarterRepoCollections()
+
+    expect(collections.length).toBeGreaterThanOrEqual(3)
+    expect(collections.map((collection) => collection.slug)).toEqual(["ai-tooling", "developer-tools", "infrastructure"])
+    expect(collections.every((collection) => collection.repos.length >= 2)).toBe(true)
+  })
+
+  test("flattens starter repo cards in collection order for quick empty-state rendering", () => {
+    const cards = getStarterRepoCards(4)
+
+    expect(cards).toHaveLength(4)
+    expect(cards.map((card) => card.fullName)).toEqual([
+      "openai/codex",
+      "anthropics/claude-code",
+      "vercel/next.js",
+      "oven-sh/bun",
+    ])
+  })
+
+  test("builds a direct lookup by full repo name for compare and queue shortcuts", () => {
+    const lookup = buildStarterRepoLookup()
+
+    expect(lookup["openai/codex"]).toMatchObject({
+      owner: "openai",
+      repo: "codex",
+      collectionSlug: "ai-tooling",
+    })
+    expect(lookup["grafana/grafana"]).toMatchObject({
+      collectionSlug: "infrastructure",
+    })
+  })
+})

--- a/web/src/app/bookmarks/page.tsx
+++ b/web/src/app/bookmarks/page.tsx
@@ -1,23 +1,30 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
-import { ArrowRight, Bookmark, Trash2 } from "lucide-react"
+import { ArrowRight, Bookmark, Search, Trash2, X } from "lucide-react"
 
+import { CompareBar, CompareToggle } from "@/components/compare-toggle"
 import { RepoShell } from "@/components/repo-shell"
-import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
+import { filterLocalRepoCollection, summarizeLocalRepoCollection } from "@/lib/local-repo-collection"
 import { cn } from "@/lib/utils"
 import { type BookmarkEntry, getBookmarks, removeBookmark } from "@/lib/bookmarks"
 
 export default function BookmarksPage() {
   const [bookmarks, setBookmarks] = useState<BookmarkEntry[]>([])
   const [mounted, setMounted] = useState(false)
+  const [query, setQuery] = useState("")
 
   useEffect(() => {
     setMounted(true)
     setBookmarks(getBookmarks())
   }, [])
+
+  const filteredBookmarks = useMemo(
+    () => filterLocalRepoCollection(bookmarks.map((entry) => ({ ...entry, savedAt: entry.bookmarkedAt, secondaryLabel: entry.bookmarkedAt })), query),
+    [bookmarks, query],
+  )
 
   const handleRemove = (fullName: string) => {
     removeBookmark(fullName)
@@ -28,10 +35,11 @@ export default function BookmarksPage() {
     <RepoShell
       eyebrow="Bookmarks"
       title="Your saved repositories."
-      description="Repositories you have bookmarked for quick access. Bookmarks are stored locally in your browser."
+      description="Repositories you have bookmarked for quick access. Search them locally and build compare sets directly from the repositories you already care about."
       compact
     >
       <section className="space-y-6">
+        <CompareBar />
         {!mounted ? (
           <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
             Loading bookmarks...
@@ -56,43 +64,78 @@ export default function BookmarksPage() {
             </div>
           </div>
         ) : (
-          <div className="overflow-hidden rounded-md border border-border bg-card">
-            {bookmarks.map((bookmark) => (
-              <div
-                key={bookmark.fullName}
-                className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
-              >
-                <div className="min-w-0 flex-1 space-y-1">
-                  <Link
-                    href={`/${bookmark.owner}/${bookmark.repo}`}
-                    className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
-                  >
-                    {bookmark.fullName}
-                  </Link>
-                  <div className="text-xs text-muted-foreground">
-                    Bookmarked {new Date(bookmark.bookmarkedAt).toLocaleDateString()}
-                  </div>
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <Link
-                    href={`/${bookmark.owner}/${bookmark.repo}`}
-                    className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
-                  >
-                    Open
-                    <ArrowRight className="h-3.5 w-3.5" />
-                  </Link>
+          <>
+            <div className="space-y-3 rounded-md border border-border bg-card p-4 sm:p-5">
+              <span className="text-sm text-muted-foreground">
+                {summarizeLocalRepoCollection(filteredBookmarks.length, bookmarks.length, query)}
+              </span>
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  type="search"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Filter bookmarked repositories..."
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 pl-9 pr-10 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+                />
+                {query ? (
                   <button
                     type="button"
-                    onClick={() => handleRemove(bookmark.fullName)}
-                    className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
-                    aria-label={`Remove ${bookmark.fullName} from bookmarks`}
+                    onClick={() => setQuery("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label="Clear bookmarked repository search"
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <X className="h-4 w-4" />
                   </button>
-                </div>
+                ) : null}
               </div>
-            ))}
-          </div>
+            </div>
+
+            {filteredBookmarks.length === 0 ? (
+              <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+                No bookmarked repositories match <span className="font-medium text-foreground">“{query.trim()}”</span>.
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-md border border-border bg-card">
+                {filteredBookmarks.map((bookmark) => (
+                  <div
+                    key={bookmark.fullName}
+                    className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
+                  >
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <Link
+                        href={`/${bookmark.owner}/${bookmark.repo}`}
+                        className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                      >
+                        {bookmark.fullName}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">
+                        Bookmarked {new Date(bookmark.savedAt).toLocaleDateString()}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap items-center gap-2 justify-end">
+                      <CompareToggle fullName={bookmark.fullName} showLabel />
+                      <Link
+                        href={`/${bookmark.owner}/${bookmark.repo}`}
+                        className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
+                      >
+                        Open
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(bookmark.fullName)}
+                        className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
+                        aria-label={`Remove ${bookmark.fullName} from bookmarks`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
         )}
       </section>
     </RepoShell>

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { ArrowRight, Download, GitCompareArrows, Plus, RefreshCcw, Trash2, X } from "lucide-react"
 
 import { RepoShell } from "@/components/repo-shell"
+import { StarterRepoGrid } from "@/components/starter-repo-grid"
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
 import {
@@ -530,7 +531,7 @@ function CompareContent() {
           </div>
         </div>
       ) : selection.length === 0 ? (
-        <div className="rounded-md border border-border bg-card p-6">
+        <div className="space-y-4 rounded-md border border-border bg-card p-6">
           <div className="flex items-start gap-4">
             <GitCompareArrows className="mt-1 h-5 w-5 text-muted-foreground" />
             <div className="space-y-3">
@@ -544,6 +545,10 @@ function CompareContent() {
               </Link>
             </div>
           </div>
+          <StarterRepoGrid
+            title="Need a few good compare candidates?"
+            description="Use these starter repositories to seed your first side-by-side comparison, even before this browser has any recent or bookmarked repos."
+          />
         </div>
       ) : null}
 

--- a/web/src/app/discover/page.tsx
+++ b/web/src/app/discover/page.tsx
@@ -7,6 +7,7 @@ import { ArrowRight, Calendar, Clock, GitFork, Shuffle, Star } from "lucide-reac
 import { BookmarkButton } from "@/components/bookmark-button"
 import { CompareToggle } from "@/components/compare-toggle"
 import { RepoShell } from "@/components/repo-shell"
+import { StarterRepoGrid } from "@/components/starter-repo-grid"
 import { WatchButton } from "@/components/watch-button"
 import { Badge } from "@/components/ui/badge"
 import type { RepoListItem, RepoListView } from "@/lib/repository-list"
@@ -211,9 +212,15 @@ export default function DiscoverPage() {
             ? Array.from({ length: 6 }).map((_, i) => <SkeletonCard key={i} />)
             : items.length === 0
               ? (
-                <p className="col-span-full text-sm text-muted-foreground">
-                  No cached repositories found. Queue some repos first.
-                </p>
+                <div className="col-span-full space-y-4">
+                  <p className="text-sm text-muted-foreground">
+                    No cached repositories found. Queue some repos first.
+                  </p>
+                  <StarterRepoGrid
+                    title="Nothing cached yet? Start with these repos."
+                    description="Open a few recognizable repository routes now, then come back here once your own queue and local workspace start filling in."
+                  />
+                </div>
               )
               : items.map((item) => (
                 <DiscoverCard key={item.fullName} item={item} />

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import { QueueInput } from "@/components/queue-input"
 import { RandomDiscoveryButton } from "@/components/random-discovery-button"
 import { RecentlyViewedWidget } from "@/components/recently-viewed-widget"
 import { RepoShell } from "@/components/repo-shell"
+import { StarterRepoGrid } from "@/components/starter-repo-grid"
 import { TrendingRepos } from "@/components/trending-repos"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
@@ -134,6 +135,10 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+
+      <div className="mt-10 sm:mt-14">
+        <StarterRepoGrid />
+      </div>
 
       <div className="mt-10 sm:mt-14">
         <LocalWorkspacePanel />

--- a/web/src/app/recent/page.tsx
+++ b/web/src/app/recent/page.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
-import { ArrowRight, Clock, Trash2 } from "lucide-react"
+import { ArrowRight, Clock, Search, Trash2, X } from "lucide-react"
 
+import { CompareBar, CompareToggle } from "@/components/compare-toggle"
 import { RepoShell } from "@/components/repo-shell"
 import { buttonVariants } from "@/components/ui/button"
+import { filterLocalRepoCollection, summarizeLocalRepoCollection } from "@/lib/local-repo-collection"
 import { cn } from "@/lib/utils"
 import { type HistoryEntry, getHistory, removeHistory, clearHistory } from "@/lib/history"
 
@@ -27,11 +29,17 @@ function formatRelativeTime(dateStr: string): string {
 export default function RecentPage() {
   const [history, setHistory] = useState<HistoryEntry[]>([])
   const [mounted, setMounted] = useState(false)
+  const [query, setQuery] = useState("")
 
   useEffect(() => {
     setMounted(true)
     setHistory(getHistory())
   }, [])
+
+  const filteredHistory = useMemo(
+    () => filterLocalRepoCollection(history.map((entry) => ({ ...entry, savedAt: entry.visitedAt, secondaryLabel: entry.visitedAt })), query),
+    [history, query],
+  )
 
   const handleRemove = (fullName: string) => {
     removeHistory(fullName)
@@ -47,10 +55,11 @@ export default function RecentPage() {
     <RepoShell
       eyebrow="Recently Viewed"
       title="Your browsing history."
-      description="Repositories you have recently visited. History is stored locally in your browser."
+      description="Repositories you have recently visited. Search locally, add useful entries straight to compare, and keep the list tidy without leaving the page."
       compact
     >
       <section className="space-y-6">
+        <CompareBar />
         {!mounted ? (
           <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
             Loading history...
@@ -76,56 +85,86 @@ export default function RecentPage() {
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-muted-foreground">
-                {history.length} recent {history.length === 1 ? "repository" : "repositories"}
-              </span>
-              <button
-                type="button"
-                onClick={handleClear}
-                className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs text-muted-foreground hover:text-rose-500")}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                Clear history
-              </button>
-            </div>
-            <div className="overflow-hidden rounded-md border border-border bg-card">
-              {history.map((entry) => (
-                <div
-                  key={entry.fullName}
-                  className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
+            <div className="space-y-3 rounded-md border border-border bg-card p-4 sm:p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="text-sm text-muted-foreground">
+                  {summarizeLocalRepoCollection(filteredHistory.length, history.length, query)}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs text-muted-foreground hover:text-rose-500")}
                 >
-                  <div className="min-w-0 flex-1 space-y-1">
-                    <Link
-                      href={`/${entry.owner}/${entry.repo}`}
-                      className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
-                    >
-                      {entry.fullName}
-                    </Link>
-                    <div className="text-xs text-muted-foreground">
-                      Viewed {formatRelativeTime(entry.visitedAt)}
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Clear history
+                </button>
+              </div>
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  type="search"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Filter recent repositories..."
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 pl-9 pr-10 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+                />
+                {query ? (
+                  <button
+                    type="button"
+                    onClick={() => setQuery("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label="Clear recent repository search"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            {filteredHistory.length === 0 ? (
+              <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+                No recent repositories match <span className="font-medium text-foreground">“{query.trim()}”</span>.
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-md border border-border bg-card">
+                {filteredHistory.map((entry) => (
+                  <div
+                    key={entry.fullName}
+                    className="flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0"
+                  >
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <Link
+                        href={`/${entry.owner}/${entry.repo}`}
+                        className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                      >
+                        {entry.fullName}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">
+                        Viewed {formatRelativeTime(entry.savedAt)}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap items-center gap-2 justify-end">
+                      <CompareToggle fullName={entry.fullName} showLabel />
+                      <Link
+                        href={`/${entry.owner}/${entry.repo}`}
+                        className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
+                      >
+                        Open
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(entry.fullName)}
+                        className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
+                        aria-label={`Remove ${entry.fullName} from history`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
                     </div>
                   </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    <Link
-                      href={`/${entry.owner}/${entry.repo}`}
-                      className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
-                    >
-                      Open
-                      <ArrowRight className="h-3.5 w-3.5" />
-                    </Link>
-                    <button
-                      type="button"
-                      onClick={() => handleRemove(entry.fullName)}
-                      className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
-                      aria-label={`Remove ${entry.fullName} from history`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
           </>
         )}
       </section>

--- a/web/src/app/repos/page.tsx
+++ b/web/src/app/repos/page.tsx
@@ -13,6 +13,7 @@ import { RepoTagFilter } from "@/components/repo-tag-filter"
 import { RepoListKeyboardProvider } from "@/components/repo-keyboard-provider"
 import { RepoViewToggle } from "@/components/repo-view-toggle"
 import { RepoListView } from "@/components/repo-list-view"
+import { StarterRepoGrid } from "@/components/starter-repo-grid"
 import { buttonVariants } from "@/components/ui/button"
 import { REPO_LIST_PAGE_SIZE, type RepoListOrder, type RepoListStatusFilter, type RepoListView as RepoListViewType } from "@/lib/repository-list"
 import { buildRepoListHref, normalizeRepoListQuery, parseRepoListOrder, parseRepoListPage, parseRepoListStatusFilter } from "@/lib/repository-list-query"
@@ -243,6 +244,10 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
               title="Keep exploring from local context"
               description="Discofork can still help you bounce between repositories you already viewed, bookmarked, or watched in this browser while the shared backend cache is unavailable."
             />
+            <StarterRepoGrid
+              title="No shared cache yet? Start with familiar repos."
+              description="These starter routes give first-time visitors something concrete to open, queue, and add to compare while the backend index is unavailable."
+            />
           </div>
         ) : displayView.items.length === 0 ? (
           <div className="rounded-md border border-border bg-card p-6 space-y-4">
@@ -264,6 +269,12 @@ export default async function ReposPage({ searchParams }: RepoIndexPageProps) {
                 <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Queue a repository</div>
                 <QueueInput placeholder="owner/repo or GitHub URL" />
               </div>
+            ) : null}
+            {!language && !view.query ? (
+              <StarterRepoGrid
+                title="Start browsing with a few strong examples"
+                description="Open or compare these recognizable repositories while you wait for the first cached reports to land."
+              />
             ) : null}
           </div>
         ) : (

--- a/web/src/app/watched/page.tsx
+++ b/web/src/app/watched/page.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
-import { ArrowRight, Eye, RefreshCw, Trash2 } from "lucide-react"
+import { ArrowRight, Eye, RefreshCw, Search, Trash2, X } from "lucide-react"
 
+import { CompareBar, CompareToggle } from "@/components/compare-toggle"
 import { RepoShell } from "@/components/repo-shell"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
+import { filterLocalRepoCollection, summarizeLocalRepoCollection } from "@/lib/local-repo-collection"
 import {
   chunkWatchFullNames,
   getWatchActivity,
@@ -67,6 +69,7 @@ export default function WatchedPage() {
   const [activityByFullName, setActivityByFullName] = useState<Record<string, WatchActivitySource>>({})
   const [activityLoaded, setActivityLoaded] = useState(false)
   const [mounted, setMounted] = useState(false)
+  const [query, setQuery] = useState("")
 
   useEffect(() => {
     setMounted(true)
@@ -136,6 +139,22 @@ export default function WatchedPage() {
     }))
   }, [watches, activityByFullName])
 
+  const filteredRows = useMemo(
+    () =>
+      filterLocalRepoCollection(
+        watchRows.map((row) => ({
+          ...row,
+          fullName: row.watch.fullName,
+          owner: row.watch.owner,
+          repo: row.watch.repo,
+          savedAt: row.watch.watchedAt,
+          secondaryLabel: row.watch.watchedAt,
+        })),
+        query,
+      ),
+    [query, watchRows],
+  )
+
   const updatedCount = watchRows.filter((row) => row.activity.status === "updated").length
 
   const handleRemove = (fullName: string) => {
@@ -147,10 +166,11 @@ export default function WatchedPage() {
     <RepoShell
       eyebrow="Watched"
       title="Repositories you are watching."
-      description="Repositories you are watching for updates. When cached data changes after your last visit, a badge will indicate new activity. Watches are stored locally in your browser."
+      description="Repositories you are watching for updates. Filter the list locally and add the most interesting repos straight into compare when fresh cache activity appears."
       compact
     >
       <section className="space-y-6">
+        <CompareBar />
         {!mounted ? (
           <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
             Loading watched repositories...
@@ -176,96 +196,128 @@ export default function WatchedPage() {
           </div>
         ) : (
           <>
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <span className="text-sm text-muted-foreground">
-                {updatedCount > 0
-                  ? `${updatedCount} watched ${updatedCount === 1 ? "repository has" : "repositories have"} fresh cache activity`
-                  : `${watches.length} watched ${watches.length === 1 ? "repository" : "repositories"}`}
-              </span>
-              {!activityLoaded ? (
-                <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
-                  <RefreshCw className="h-3.5 w-3.5 animate-spin" />
-                  Checking cached activity…
+            <div className="space-y-3 rounded-md border border-border bg-card p-4 sm:p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="text-sm text-muted-foreground">
+                  {query
+                    ? summarizeLocalRepoCollection(filteredRows.length, watchRows.length, query)
+                    : updatedCount > 0
+                      ? `${updatedCount} watched ${updatedCount === 1 ? "repository has" : "repositories have"} fresh cache activity`
+                      : summarizeLocalRepoCollection(filteredRows.length, watchRows.length, query)}
                 </span>
-              ) : null}
-            </div>
-            <div className="overflow-hidden rounded-md border border-border bg-card">
-              {watchRows.map(({ watch, activity }) => {
-                const cachedFreshness = formatRelativeTime(activity.cachedAt)
-
-                return (
-                  <div
-                    key={watch.fullName}
-                    className={cn(
-                      "flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0",
-                      activity.status === "updated" && "bg-emerald-500/5",
-                    )}
+                {!activityLoaded ? (
+                  <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                    <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                    Checking cached activity…
+                  </span>
+                ) : null}
+              </div>
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  type="search"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Filter watched repositories..."
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 pl-9 pr-10 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-ring"
+                />
+                {query ? (
+                  <button
+                    type="button"
+                    onClick={() => setQuery("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label="Clear watched repository search"
                   >
-                    <div className="min-w-0 flex-1 space-y-2">
-                      <div className="flex flex-wrap items-center gap-2">
+                    <X className="h-4 w-4" />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            {filteredRows.length === 0 ? (
+              <div className="rounded-md border border-border bg-card p-6 text-sm leading-7 text-muted-foreground">
+                No watched repositories match <span className="font-medium text-foreground">“{query.trim()}”</span>.
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-md border border-border bg-card">
+                {filteredRows.map(({ watch, activity }) => {
+                  const cachedFreshness = formatRelativeTime(activity.cachedAt)
+
+                  return (
+                    <div
+                      key={watch.fullName}
+                      className={cn(
+                        "flex items-center justify-between gap-4 border-b border-border px-5 py-4 last:border-b-0",
+                        activity.status === "updated" && "bg-emerald-500/5",
+                      )}
+                    >
+                      <div className="min-w-0 flex-1 space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Link
+                            href={`/${watch.owner}/${watch.repo}`}
+                            className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                          >
+                            {watch.fullName}
+                          </Link>
+                          {activity.status === "updated" ? <Badge variant="success">Updated</Badge> : null}
+                          {activity.status === "cached" ? (
+                            <Badge variant="muted">Cached {cachedFreshness ?? formatDate(activity.cachedAt ?? "")}</Badge>
+                          ) : null}
+                          {activity.status === "missing" && activityLoaded ? (
+                            <Badge variant="muted">No cached snapshot yet</Badge>
+                          ) : null}
+                          {activity.status === "unknown" && activityLoaded ? (
+                            <Badge variant="warning">Could not check cache activity</Badge>
+                          ) : null}
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                          <span>Watching since {formatDate(watch.watchedAt)}</span>
+                          <span>·</span>
+                          <span>Last visited {formatDate(watch.lastVisitedAt)}</span>
+                          {activity.cachedAt ? (
+                            <>
+                              <span>·</span>
+                              <span>
+                                {activity.status === "updated" ? "Fresh cache activity" : "Latest cache"}{" "}
+                                {cachedFreshness ?? formatDate(activity.cachedAt)}
+                              </span>
+                            </>
+                          ) : activity.status === "missing" && activityLoaded ? (
+                            <>
+                              <span>·</span>
+                              <span>No cached snapshot yet</span>
+                            </>
+                          ) : activity.status === "unknown" && activityLoaded ? (
+                            <>
+                              <span>·</span>
+                              <span>Could not check cache activity right now</span>
+                            </>
+                          ) : null}
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 flex-wrap items-center gap-2 justify-end">
+                        <CompareToggle fullName={watch.fullName} showLabel />
                         <Link
                           href={`/${watch.owner}/${watch.repo}`}
-                          className="block text-sm font-semibold text-foreground transition-colors hover:text-primary"
+                          className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
                         >
-                          {watch.fullName}
+                          Open
+                          <ArrowRight className="h-3.5 w-3.5" />
                         </Link>
-                        {activity.status === "updated" ? <Badge variant="success">Updated</Badge> : null}
-                        {activity.status === "cached" ? (
-                          <Badge variant="muted">Cached {cachedFreshness ?? formatDate(activity.cachedAt ?? "")}</Badge>
-                        ) : null}
-                        {activity.status === "missing" && activityLoaded ? (
-                          <Badge variant="muted">No cached snapshot yet</Badge>
-                        ) : null}
-                        {activity.status === "unknown" && activityLoaded ? (
-                          <Badge variant="warning">Could not check cache activity</Badge>
-                        ) : null}
-                      </div>
-                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                        <span>Watching since {formatDate(watch.watchedAt)}</span>
-                        <span>·</span>
-                        <span>Last visited {formatDate(watch.lastVisitedAt)}</span>
-                        {activity.cachedAt ? (
-                          <>
-                            <span>·</span>
-                            <span>
-                              {activity.status === "updated" ? "Fresh cache activity" : "Latest cache"}{" "}
-                              {cachedFreshness ?? formatDate(activity.cachedAt)}
-                            </span>
-                          </>
-                        ) : activity.status === "missing" && activityLoaded ? (
-                          <>
-                            <span>·</span>
-                            <span>No cached snapshot yet</span>
-                          </>
-                        ) : activity.status === "unknown" && activityLoaded ? (
-                          <>
-                            <span>·</span>
-                            <span>Could not check cache activity right now</span>
-                          </>
-                        ) : null}
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(watch.fullName)}
+                          className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
+                          aria-label={`Stop watching ${watch.fullName}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
                       </div>
                     </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <Link
-                        href={`/${watch.owner}/${watch.repo}`}
-                        className={cn(buttonVariants({ variant: "ghost" }), "gap-1.5 px-3 text-xs")}
-                      >
-                        Open
-                        <ArrowRight className="h-3.5 w-3.5" />
-                      </Link>
-                      <button
-                        type="button"
-                        onClick={() => handleRemove(watch.fullName)}
-                        className="rounded-md p-2 text-muted-foreground transition-colors hover:text-rose-500"
-                        aria-label={`Stop watching ${watch.fullName}`}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
+                  )
+                })}
+              </div>
+            )}
           </>
         )}
       </section>

--- a/web/src/components/starter-repo-grid.tsx
+++ b/web/src/components/starter-repo-grid.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+
+import { CompareToggle } from "@/components/compare-toggle"
+import { Badge } from "@/components/ui/badge"
+import { buttonVariants } from "@/components/ui/button"
+import { getStarterRepoCards, type StarterRepoCard } from "@/lib/starter-repos"
+import { cn } from "@/lib/utils"
+
+function StarterRepoCardView({ repo }: { repo: StarterRepoCard }) {
+  return (
+    <div className="rounded-xl border border-border bg-card/70 p-4 shadow-[0_20px_60px_rgba(0,0,0,0.18)]">
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="muted">{repo.collectionLabel}</Badge>
+          <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Starter repo</span>
+        </div>
+        <div className="space-y-1">
+          <div className="text-sm font-semibold text-foreground">{repo.fullName}</div>
+          <p className="text-sm leading-6 text-muted-foreground">{repo.description}</p>
+        </div>
+      </div>
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Link href={repo.canonicalPath} className={cn(buttonVariants({ variant: "outline" }), "h-8 rounded-full px-3 text-xs")}>
+          Open repo
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+        <CompareToggle fullName={repo.fullName} compact />
+      </div>
+    </div>
+  )
+}
+
+export function StarterRepoGrid({
+  title = "Starter repos for first-time visitors",
+  description = "Use a few recognizable repositories to explore Discofork before your own local history or backend cache has warmed up.",
+  limit = 4,
+}: {
+  title?: string
+  description?: string
+  limit?: number
+}) {
+  const repos = getStarterRepoCards(limit)
+
+  return (
+    <section className="space-y-4 rounded-[1.25rem] border border-border bg-card/60 p-5 sm:p-6">
+      <div className="space-y-2">
+        <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">Starter launchpad</div>
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        <p className="text-sm leading-7 text-muted-foreground">{description}</p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {repos.map((repo) => (
+          <StarterRepoCardView key={repo.fullName} repo={repo} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web/src/lib/local-repo-collection.ts
+++ b/web/src/lib/local-repo-collection.ts
@@ -1,0 +1,28 @@
+export type LocalRepoCollectionEntry = {
+  fullName: string
+  owner: string
+  repo: string
+  savedAt: string
+  secondaryLabel: string
+}
+
+export function filterLocalRepoCollection<T extends LocalRepoCollectionEntry>(entries: T[], query: string): T[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return entries
+  }
+
+  return entries.filter((entry) => {
+    const haystacks = [entry.fullName, entry.owner, entry.repo]
+    return haystacks.some((value) => value.toLowerCase().includes(normalizedQuery))
+  })
+}
+
+export function summarizeLocalRepoCollection(filteredCount: number, totalCount: number, query: string): string {
+  const normalizedQuery = query.trim()
+  if (!normalizedQuery) {
+    return `${totalCount} ${totalCount === 1 ? "repository" : "repositories"}`
+  }
+
+  return `${filteredCount} ${filteredCount === 1 ? "match" : "matches"} for “${normalizedQuery}”`
+}

--- a/web/src/lib/starter-repos.ts
+++ b/web/src/lib/starter-repos.ts
@@ -1,0 +1,117 @@
+export type StarterRepoCard = {
+  owner: string
+  repo: string
+  fullName: string
+  canonicalPath: string
+  collectionSlug: string
+  collectionLabel: string
+  title: string
+  description: string
+}
+
+export type StarterRepoCollection = {
+  slug: string
+  label: string
+  description: string
+  repos: StarterRepoCard[]
+}
+
+const STARTER_REPO_COLLECTIONS: StarterRepoCollection[] = [
+  {
+    slug: "ai-tooling",
+    label: "AI tooling",
+    description: "Strong starter repos for people exploring coding agents, inference tooling, and model workflows.",
+    repos: [
+      {
+        owner: "openai",
+        repo: "codex",
+        fullName: "openai/codex",
+        canonicalPath: "/openai/codex",
+        collectionSlug: "ai-tooling",
+        collectionLabel: "AI tooling",
+        title: "Codex CLI",
+        description: "Agentic coding from the terminal, with a repo route that makes Discofork's cached summary useful immediately.",
+      },
+      {
+        owner: "anthropics",
+        repo: "claude-code",
+        fullName: "anthropics/claude-code",
+        canonicalPath: "/anthropics/claude-code",
+        collectionSlug: "ai-tooling",
+        collectionLabel: "AI tooling",
+        title: "Claude Code",
+        description: "Another agent-oriented coding repo that helps visitors compare workflow trade-offs quickly.",
+      },
+    ],
+  },
+  {
+    slug: "developer-tools",
+    label: "Developer tools",
+    description: "Widely recognized repos that make the product legible for new visitors fast.",
+    repos: [
+      {
+        owner: "vercel",
+        repo: "next.js",
+        fullName: "vercel/next.js",
+        canonicalPath: "/vercel/next.js",
+        collectionSlug: "developer-tools",
+        collectionLabel: "Developer tools",
+        title: "Next.js",
+        description: "A familiar high-signal repo for testing cached briefs, summaries, and queue behavior.",
+      },
+      {
+        owner: "oven-sh",
+        repo: "bun",
+        fullName: "oven-sh/bun",
+        canonicalPath: "/oven-sh/bun",
+        collectionSlug: "developer-tools",
+        collectionLabel: "Developer tools",
+        title: "Bun",
+        description: "Useful for seeing how Discofork handles a fast-moving runtime with lots of forks and stars.",
+      },
+    ],
+  },
+  {
+    slug: "infrastructure",
+    label: "Infrastructure",
+    description: "Ops-heavy repos for testing summary depth and comparison workflows on backend-focused projects.",
+    repos: [
+      {
+        owner: "grafana",
+        repo: "grafana",
+        fullName: "grafana/grafana",
+        canonicalPath: "/grafana/grafana",
+        collectionSlug: "infrastructure",
+        collectionLabel: "Infrastructure",
+        title: "Grafana",
+        description: "A large mature platform repo that makes fork triage and cached summaries more tangible.",
+      },
+      {
+        owner: "redis",
+        repo: "redis",
+        fullName: "redis/redis",
+        canonicalPath: "/redis/redis",
+        collectionSlug: "infrastructure",
+        collectionLabel: "Infrastructure",
+        title: "Redis",
+        description: "A foundational infra project that gives first-time visitors another recognizable comparison candidate.",
+      },
+    ],
+  },
+]
+
+export function getStarterRepoCollections(): StarterRepoCollection[] {
+  return STARTER_REPO_COLLECTIONS.map((collection) => ({
+    ...collection,
+    repos: collection.repos.map((repo) => ({ ...repo })),
+  }))
+}
+
+export function getStarterRepoCards(limit?: number): StarterRepoCard[] {
+  const cards = STARTER_REPO_COLLECTIONS.flatMap((collection) => collection.repos.map((repo) => ({ ...repo })))
+  return typeof limit === "number" ? cards.slice(0, limit) : cards
+}
+
+export function buildStarterRepoLookup(): Record<string, StarterRepoCard> {
+  return Object.fromEntries(getStarterRepoCards().map((repo) => [repo.fullName, repo]))
+}


### PR DESCRIPTION
## Summary
- add a reusable starter-repo launchpad so first-time visitors can open and compare recognizable repos even when cache/local history is empty
- add local search + compare-in-place workflows to Recent, Bookmarks, and Watched pages
- improve empty states on Home, Repos, Discover, and Compare to keep the app useful before backend data warms up

## Test Plan
- bun test test/starter-repos.test.ts test/local-repo-collection.test.ts test/repo-launcher.test.ts test/compare-selection.test.ts test/watches.test.ts
- cd web && bun run typecheck
- browser verification on /, /repos, /recent, and /compare with seeded localStorage state and no console errors